### PR TITLE
Verify UTC zoneid as normalized object

### DIFF
--- a/tck/src/main/java/jakarta/json/bind/tck/defaultmapping/dates/DatesMappingTest.java
+++ b/tck/src/main/java/jakarta/json/bind/tck/defaultmapping/dates/DatesMappingTest.java
@@ -464,8 +464,8 @@ public class DatesMappingTest {
    */
   @Test
   public void testZoneIdMapping() {
-    new MappingTester<>(ZoneIdContainer.class).test(ZoneId.of("UTC"),
-        "\"UTC\"");
+    new MappingTester<>(ZoneIdContainer.class).test(ZoneId.of("UTC").normalized(),
+        "\"Z\"");
   }
 
   /*


### PR DESCRIPTION
Recently it was pointed out by @MartijnDwars [in this Yasson issue](https://github.com/eclipse-ee4j/yasson/issues/387) that we were not serializing `ZoneId.of("UTC")` correctly:

JSON-B spec section  3.5.3 states:
> Implementations MUST support the deserialization of any time zone ID format specified in java.time.ZoneId into a field or property of type java.time.ZoneId. The serialization format of java.time.ZoneId is the normalized zone ID as specified in java.time.ZoneId.

Martijn pointed out the following in his issue:

> The normalized part makes a difference when you have a ZoneId.of("UTC"), for example. The zone ID is "UTC", but the normalized zone ID is "Z", as shown by this jshell session:

```
jshell> import java.time.*;

jshell> ZoneId.of("UTC").getId()
$2 ==> "UTC"

jshell> ZoneId.of("UTC").normalized().getId()
$3 ==> "Z"
```

One of the Yasson contributors, @Degubi, fixed this issue in a Yasson PR.

When running the Yasson TCK with this change, I noticed that one test was expecting the incorrect behavior. It was expecting `ZoneId.of("UTC")` to be serialized as the string `"UTC"`, but it should be normalized to `"Z"`