### PR TITLE
remove references to JavaTest.

### DIFF
--- a/tck-docs/userguide/src/main/jbake/content/intro.adoc
+++ b/tck-docs/userguide/src/main/jbake/content/intro.adoc
@@ -290,7 +290,7 @@ steps are explained in more detail in subsequent chapters of this
 guide.
 
 1.  Make sure that the following software has been correctly installed
-on the system hosting the JavaTest harness:
+on the system:
 include::req-software.inc[]
 * Java SE {SEversion}
 * A CI for {TechnologyShortName} {TechnologyVersion}. One example is {TechnologyRI}.

--- a/tck-docs/userguide/src/main/jbake/content/using.adoc
+++ b/tck-docs/userguide/src/main/jbake/content/using.adoc
@@ -129,7 +129,7 @@ Repackage and Run the TCK Against the Vendor Implementation."]
 link:config.html#GCLIL[Section 4.3.3, "Deploying the
 Test Applications Against the Vendor Implementation."]
 3.  Run the tests, as described in link:#GBFUZ[Section 5.1, "Starting
-JavaTest,"] and, if desired, link:#GBFWM[Section 5.2, "Running a Subset
+ the Test run,"] and, if desired, link:#GBFWM[Section 5.2, "Running a Subset
 of the Tests."]
 
 [[GBFVK]][[test-reports]]


### PR DESCRIPTION
remove references to JavaTest from TCK user-guide.
Signed-off-by: gurunrao <gurunandan.rao@oracle.com>