### PR TITLE
fixes: #360 challenge for NumberFormatCustomizationTest

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/NumberFormatCustomizationTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/NumberFormatCustomizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/model/AccessorCustomizedDoubleContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/model/AccessorCustomizedDoubleContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,7 +29,7 @@ public class AccessorCustomizedDoubleContainer
     private Double instance;
 
     @Override
-    @JsonbNumberFormat(value = "###,###.##")
+    @JsonbNumberFormat(value = "###,###.##", locale = "en_US")
     public Double getInstance() {
         return instance;
     }

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/model/TypeCustomizedDoubleContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/model/TypeCustomizedDoubleContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,7 +24,7 @@ import jakarta.json.bind.annotation.JsonbNumberFormat;
 
 import ee.jakarta.tck.json.bind.TypeContainer;
 
-@JsonbNumberFormat(value = "###,###.##")
+@JsonbNumberFormat(value = "###,###.##", locale = "en_US")
 public class TypeCustomizedDoubleContainer implements TypeContainer<Double> {
     private Double instance;
 

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/model/TypeCustomizedFieldOverriddenDoubleContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/model/TypeCustomizedFieldOverriddenDoubleContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,10 +24,10 @@ import jakarta.json.bind.annotation.JsonbNumberFormat;
 
 import ee.jakarta.tck.json.bind.TypeContainer;
 
-@JsonbNumberFormat(value = "###,###.##")
+@JsonbNumberFormat(value = "###,###.##", locale = "en_US")
 public class TypeCustomizedFieldOverriddenDoubleContainer
         implements TypeContainer<Double> {
-    @JsonbNumberFormat(value = "###,###.#")
+    @JsonbNumberFormat(value = "###,###.#", locale = "en_US")
     private Double instance;
 
     @Override

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/model/customized/PackageCustomizedTypeOverriddenDoubleContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/numberformat/model/customized/PackageCustomizedTypeOverriddenDoubleContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,7 +24,7 @@ import jakarta.json.bind.annotation.JsonbNumberFormat;
 
 import ee.jakarta.tck.json.bind.TypeContainer;
 
-@JsonbNumberFormat(value = "###,###.##")
+@JsonbNumberFormat(value = "###,###.##", locale = "en_US")
 public class PackageCustomizedTypeOverriddenDoubleContainer
         implements TypeContainer<Double> {
     private Double instance;


### PR DESCRIPTION
A @JsonbNumberFormat(value = "###,###.##") without any specified locale results in a JSON serialisation which is depending on the Locale of the box you run the TCK on. This is not reproducible.

There are 2 ways to define the Locale:
* with the JsonbNumberFormat#locale attribute
* with JsonbConfig#withLocale

This test at least pins down the Locale to guarantee reproducible builds.