### PR TITLE
Section 4.2 is unclear

### DIFF
--- a/spec/src/main/asciidoc/jsonb.adoc
+++ b/spec/src/main/asciidoc/jsonb.adoc
@@ -616,7 +616,7 @@ If duplicate name is found exception MUST be thrown. The definition of duplicate
 
 === Customizing Property Order
 
-To customize the order of serialized properties, JSON Binding provides `jakarta.json.bind.config.PropertyOrderStrategy` class.
+To customize the order of serialized properties, JSON Binding provides the `jakarta.json.bind.config.PropertyOrderStrategy` class.
 
 Class `jakarta.json.bind.config.PropertyOrderStrategy` provides the most common property order strategies.
 
@@ -624,11 +624,11 @@ Class `jakarta.json.bind.config.PropertyOrderStrategy` provides the most common 
 * ANY
 * REVERSE
 
-The detailed description of property order strategies can be found in javadoc.
+Detailed descriptions of property order strategies can be found in the javadoc.
 
-The way to set custom property order strategy is to use `jakarta.json.bind.JsonbConfig::withPropertyOrderStrategy` method.
+Use the `jakarta.json.bind.JsonbConfig::withPropertyOrderStrategy` method to configure a custom property order strategy.
 
-To customize the order of serialized properties only for one specific type, JSON Binding provides `jakarta.json.bind.annotation.JsonbPropertyOrder` annotation. Order specified by `JsonbPropertyOrder` annotation overrides order specified by `PropertyOrderStrategy`.
+To customize the order of serialized properties only for one specific type, JSON Binding provides the `jakarta.json.bind.annotation.JsonbPropertyOrder` annotation. The order specified by the `JsonbPropertyOrder` annotation overrides the order specified by `PropertyOrderStrategy`.
 
 A `PropertyOrderStrategy` determines the order based on the already renamed properties that have been customized according to the rules outlined under section 4.1.
 

--- a/spec/src/main/asciidoc/jsonb.adoc
+++ b/spec/src/main/asciidoc/jsonb.adoc
@@ -630,7 +630,7 @@ The way to set custom property order strategy is to use `jakarta.json.bind.Jsonb
 
 To customize the order of serialized properties only for one specific type, JSON Binding provides `jakarta.json.bind.annotation.JsonbPropertyOrder` annotation. Order specified by `JsonbPropertyOrder` annotation overrides order specified by `PropertyOrderStrategy`.
 
-The order is applied to already renamed properties as stated in 4.1.
+A `PropertyOrderStrategy` determines the order based on the already renamed properties that have been customized according to the rules outlined under section 4.1.
 
 === Customizing Null Handling
 


### PR DESCRIPTION
While answering a question from a user, I read through section [4.2 on Customizing Property Order](https://jakarta.ee/specifications/jsonb/3.0/jakarta-jsonb-spec-3.0#customizing-property-order) and [JsonbPropertyOrder Javadoc](https://jakarta.ee/specifications/jsonb/3.0/apidocs/jakarta.json.bind/jakarta/json/bind/annotation/jsonbpropertyorder#value()) regarding whether original property names vs customized property names are used in determining the order.

Section 4.2 is unclear because in one place it defers to `JsonbPropertyOrder`,
```
To customize the order of serialized properties only for one specific type, JSON Binding provides jakarta.json.bind.annotation.JsonbPropertyOrder annotation. Order specified by JsonbPropertyOrder annotation overrides order specified by PropertyOrderStrategy.
```

but immediately after that states that `The order is applied to already renamed properties as stated in 4.1`, which would contradict JsonbPropertyOrder's statement that `Names must correspond to original names defined in Java class before any customization applied.`

After rereading these seemingly conflicting statements several times over, I finally realized that the line at the end of section 4.2 isn't meant to apply to `JsonbPropertyOrder` that was discussed immediately before it.  Instead, it is intended only for `PropertyOrderStrategy`.

The PR adds clarification to that line of section 4.2 (first commit).  A second commit adds a few grammar corrections that I noticed in that same section.  If anyone doesn't want the grammar corrections part, just let me know and I'll remove that commit.