### PR TITLE
finalize: relationship between @JsonbCreator and records

### DIFF
--- a/_context/plans/.gitignore
+++ b/_context/plans/.gitignore
@@ -1,3 +1,3 @@
 # Ignore all plan files
 # These are ephemeral plans only used by a local developer
-.md
+*.md

--- a/api/src/main/java/jakarta/json/bind/annotation/JsonbCreator.java
+++ b/api/src/main/java/jakarta/json/bind/annotation/JsonbCreator.java
@@ -22,10 +22,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>By default, deserialization creates an instance object by invoking the class's default constructor
- * or the record's canonical constructor. The canonical constructor of a record can be explicitly overridden
- * by declaring an all-args constructor or a compact constructor and will still be used as the default path 
- * for deserialization without requiring {@code @JsonbCreator}.</p>
+ * <p>By default, deserialization of a class invokes its no-argument constructor, and deserialization
+ * of a record invokes its canonical constructor. A record may also declare a compact constructor
+ * whose body is merged into the canonical constructor at compile time; the two are indistinguishable
+ * at runtime and both serve as the canonical deserialization path without requiring
+ * {@code @JsonbCreator}.</p>
  *
  * <p>This annotation identifies a custom constructor or static factory method to invoke when
  * creating an instance of the associated class or record during deserialization.</p>
@@ -42,6 +43,9 @@ import java.lang.annotation.Target;
  *   <li> method </li>
  *   <li> constructor </li>
  * </ul>
+ *
+ * <p><b>Since 3.1:</b> {@code @JsonbCreator} may also be placed on a non-canonical constructor
+ * or static factory method of a Java record to designate an alternative deserialization path.</p>
  *
  * @since JSON Binding 1.0
  */

--- a/api/src/main/java/jakarta/json/bind/annotation/JsonbCreator.java
+++ b/api/src/main/java/jakarta/json/bind/annotation/JsonbCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,13 +22,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>This annotation identifies the custom constructor or factory method to use when creating an instance
- * of the associated class.</p>
+ * <p>By default, deserialization creates an instance object by invoking the class's default constructor
+ * or the record's canonical constructor. The canonical constructor of a record can be explicitly overridden
+ * by declaring an all-args constructor or a compact constructor and will still be used as the default path 
+ * for deserialization without requiring {@code @JsonbCreator}.</p>
  *
- * <p>Only one constructor or static factory method can be annotated with {@code JsonbCreator} in a given class.</p>
+ * <p>This annotation identifies a custom constructor or static factory method to invoke when
+ * creating an instance of the associated class or record during deserialization.</p>
  *
- * <p>The {@code @JsonbCreator} annotation is intended to be used with constructors/methods with parameters.
- * Such parameters could be annotated for instance with {@code @JsonbProperty}.</p>
+ * <p>Only one constructor or static factory method per class or record may be annotated
+ * with {@code @JsonbCreator}.</p>
+ *
+ * <p>Parameters of the annotated constructor or static factory method may themselves be
+ * annotated, for example with {@link JsonbProperty}.</p>
  *
  * <p><b>Usage</b></p>
  * <p>The {@code @JsonbCreator} annotation can be used with the following program elements:</p>

--- a/api/src/main/java/jakarta/json/bind/annotation/JsonbCreator.java
+++ b/api/src/main/java/jakarta/json/bind/annotation/JsonbCreator.java
@@ -22,6 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * <p>Annotates a constructor or static factory method to use for deserialization.</p>
+ *
  * <p>By default, deserialization of a class invokes its no-argument constructor, and deserialization
  * of a record invokes its canonical constructor. A record may also declare a compact constructor
  * whose body is merged into the canonical constructor at compile time; the two are indistinguishable

--- a/docs/src/docs/user-guide.adoc
+++ b/docs/src/docs/user-guide.adoc
@@ -438,7 +438,8 @@ Jsonb jsonb = JsonbBuilder.create(nillableConfig);
 ==== Custom instantiation
 
 By default, a public default no-arguments constructor is required for deserialization of the class.
-In the case of records, the record's default constructor is required for deserialization of the record. The record can include a compact constructor if the compact constructor does not reassign any of the record components. 
+In the case of records, the record's canonical constructor is required for deserialization of the record.
+The record can include a compact constructor if the compact constructor does not reassign any of the record components. 
 
 In many scenarios this requirement is too strict. JSON-B provides @JsonbCreator annotation which can be used to annotate a custom constructor with parameters or a static factory method used to create a class instance.
 

--- a/docs/src/docs/user-guide.adoc
+++ b/docs/src/docs/user-guide.adoc
@@ -441,7 +441,7 @@ By default, a public default no-arguments constructor is required for deserializ
 In the case of records, the record's canonical constructor is used for deserialization. A compact constructor
 whose body is merged into the canonical constructor at compile time is used as the default deserialization path.
 
-In many scenarios this requirement is too strict. JSON-B provides @JsonbCreator annotation which can be used to annotate a custom constructor with parameters or a static factory method used to create a class or record instance.
+In many scenarios this requirement is too strict. JSON-B provides @JsonbCreator annotation which can be used to annotate a custom constructor that has parameters or a static factory method that creates a class or record instance.
 
 The sample below shows how @JsonbCreator annotation can be used on a custom constructor. @JsonbProperty annotation on the constructor parameter is required for proper parameter substitution. In this case a value of JSON property 'name' will be passed to the constructor.
 

--- a/docs/src/docs/user-guide.adoc
+++ b/docs/src/docs/user-guide.adoc
@@ -438,10 +438,10 @@ Jsonb jsonb = JsonbBuilder.create(nillableConfig);
 ==== Custom instantiation
 
 By default, a public default no-arguments constructor is required for deserialization of the class.
-In the case of records, the record's canonical constructor is required for deserialization of the record.
-The record can include a compact constructor if the compact constructor does not reassign any of the record components. 
+In the case of records, the record's canonical constructor is used for deserialization. A compact constructor
+whose body is merged into the canonical constructor at compile time is used as the default deserialization path.
 
-In many scenarios this requirement is too strict. JSON-B provides @JsonbCreator annotation which can be used to annotate a custom constructor with parameters or a static factory method used to create a class instance.
+In many scenarios this requirement is too strict. JSON-B provides @JsonbCreator annotation which can be used to annotate a custom constructor with parameters or a static factory method used to create a class or record instance.
 
 The sample below shows how @JsonbCreator annotation can be used on a custom constructor. @JsonbProperty annotation on the constructor parameter is required for proper parameter substitution. In this case a value of JSON property 'name' will be passed to the constructor.
 

--- a/spec/src/main/asciidoc/jsonb.adoc
+++ b/spec/src/main/asciidoc/jsonb.adoc
@@ -688,17 +688,17 @@ The result of serialization of duration must conform to the "duration" productio
 
 === Custom instantiation
 
-In many scenarios instantiation with the use of default constructor is not enough. To support these scenarios, JSON Binding provides `jakarta.json.bind.annotation.JsonbCreator` annotation.
+In many scenarios instantiation with the use of the default constructor or canonical constructor is not enough. To support these scenarios, JSON Binding provides the `jakarta.json.bind.annotation.JsonbCreator` annotation.
 
-At most one `JsonbCreator` annotation can be used to annotate custom constructor or static factory method in a class/record, otherwise `JsonbException` MUST be thrown.
+At most one `@JsonbCreator` annotation can be used to annotate a custom constructor or static factory method in a class or record, otherwise a `JsonbException` MUST be thrown.
 
-Factory method annotated with `JsonbCreator` annotation should return instance of a particular class/record this annotation is used for, otherwise `JsonbException` MUST be thrown.
+A factory method annotated with the `@JsonbCreator` annotation must return an instance of the class or record the annotated custom constructor or static factory method is defined within, otherwise a `JsonbException` MUST be thrown.
 
-Mapping between parameters of constructor/factory method annotated with `JsonbCreator` and JSON fields is defined using `JsonbProperty` annotation on all parameters.
+A JSON field is mapped to the parameter of the same name on the custom constructor or static factory method annotated by `@JsonbCreator` when the application is compiled with the `-parameters` compiler options and the parameter is not annotated with the `@JsonbProperty` annotation.
 
-If the `JsonbProperty` annotation on parameters is not used, then parameters should be mapped from JSON fields with the same name. In this case the proper mapping is NOT guaranteed.
+Otherwise, applications must explicitly define the mapping between JSON field and the parameters of the custom constructor or static factory method annotated by `@JsonbCreator` using the `@JsonbProperty` parameter annotation.
 
-All the `JsonbCreator` parameters are treated as optional by default. See <<optional-parameter-values, Optional parameter values>> chapter for default optional parameter values.
+All the `@JsonbCreator` parameters are treated as optional by default. See <<optional-parameter-values, Optional parameter values>> chapter for default optional parameter values.
 
 All the `JsonbCreator` parameters can be turned to required by using configuration method `Config::withCreatorParametersRequired`.
 

--- a/spec/src/main/asciidoc/jsonb.adoc
+++ b/spec/src/main/asciidoc/jsonb.adoc
@@ -295,7 +295,7 @@ JSON object values are deserialized into an implementation of `java.util.Map<Str
 
 Any class instance passed to a deserialization operation must have a public or protected no-argument constructor. Implementations SHOULD throw an error if this condition is not met. This limitation does not apply to serialization operations, as well as to classes which specify explicit instantiation methods as described in section 4.5.
 
-Any record instance passed to a deserialization operation must have its default generated constructor (and optionally a compact constructor that does not reassign any record component values) as its only constructor. Implementations SHOULD throw an error if this condition is not met. This limitation does not apply to serialization operations, as well as to records which specify explicit instantiation methods as described in section 4.5.
+Any record instance passed to a deserialization operation is instantiated via its canonical constructor. A compact constructor whose body is merged into the canonical constructor at compile time is indistinguishable at runtime and serves as the same deserialization path. Implementations SHOULD throw an error if this condition is not met. This limitation does not apply to serialization operations, as well as to records which specify explicit instantiation methods as described in section 4.5.
 
 ==== Scope and Field access strategy
 
@@ -692,7 +692,7 @@ In many scenarios instantiation with the use of the default constructor or canon
 
 At most one `@JsonbCreator` annotation can be used to annotate a custom constructor or static factory method in a class or record, otherwise a `JsonbException` MUST be thrown.
 
-A factory method annotated with the `@JsonbCreator` annotation must return an instance of the class or record the annotated custom constructor or static factory method is defined within, otherwise a `JsonbException` MUST be thrown.
+A factory method annotated with the `@JsonbCreator` annotation must return an instance of the class or record the annotated factory method is defined within, otherwise a `JsonbException` MUST be thrown.
 
 A JSON field is mapped to the parameter of the same name on the custom constructor or static factory method annotated by `@JsonbCreator` when the application is compiled with the `-parameters` compiler options and the parameter is not annotated with the `@JsonbProperty` annotation.
 
@@ -700,7 +700,7 @@ Otherwise, applications must explicitly define the mapping between JSON field an
 
 All the `@JsonbCreator` parameters are treated as optional by default. See <<optional-parameter-values, Optional parameter values>> chapter for default optional parameter values.
 
-All the `JsonbCreator` parameters can be turned to required by using configuration method `Config::withCreatorParametersRequired`.
+All the `@JsonbCreator` parameters can be turned to required by using configuration method `Config::withCreatorParametersRequired`.
 
 If a required field for a parameter mapping does not exist in the JSON document, then `JsonbException` MUST be thrown.
 

--- a/spec/src/main/asciidoc/jsonb.adoc
+++ b/spec/src/main/asciidoc/jsonb.adoc
@@ -295,7 +295,7 @@ JSON object values are deserialized into an implementation of `java.util.Map<Str
 
 Any class instance passed to a deserialization operation must have a public or protected no-argument constructor. Implementations SHOULD throw an error if this condition is not met. This limitation does not apply to serialization operations, as well as to classes which specify explicit instantiation methods as described in section 4.5.
 
-Any record instance passed to a deserialization operation is instantiated via its canonical constructor. A compact constructor whose body is merged into the canonical constructor at compile time is indistinguishable at runtime and serves as the same deserialization path. Implementations SHOULD throw an error if this condition is not met. This limitation does not apply to serialization operations, as well as to records which specify explicit instantiation methods as described in section 4.5.
+Any record instance passed to a deserialization operation is instantiated via its canonical constructor. A compact constructor whose body is merged into the canonical constructor at compile time is indistinguishable at runtime and corresponds to the same deserialization path. Implementations SHOULD throw an error if this condition is not met. This limitation does not apply to serialization operations, as well as to records which specify explicit instantiation methods as described in section 4.5.
 
 ==== Scope and Field access strategy
 
@@ -700,7 +700,7 @@ Otherwise, applications must explicitly define the mapping between JSON field an
 
 All the `@JsonbCreator` parameters are treated as optional by default. See <<optional-parameter-values, Optional parameter values>> chapter for default optional parameter values.
 
-All the `@JsonbCreator` parameters can be turned to required by using configuration method `Config::withCreatorParametersRequired`.
+All the `@JsonbCreator` parameters can be made required by using configuration method `Config::withCreatorParametersRequired`.
 
 If a required field for a parameter mapping does not exist in the JSON document, then `JsonbException` MUST be thrown.
 

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/RecordInstantiationTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/RecordInstantiationTest.java
@@ -68,7 +68,8 @@ public class RecordInstantiationTest {
      *
      * @test_Strategy: Assert that a static factory method annotated with
      * JsonbCreator annotation can be used to customize record instantiation
-     * during unmarshalling, with the remaining components defaulted
+     * during unmarshalling, with components not covered by the factory method
+     * set to fixed values within the factory method body
      */
     @Test
     public void testFactoryMethodPlusFields() {
@@ -212,6 +213,15 @@ public class RecordInstantiationTest {
                    c.stringInstance(), is(expected));
     }
 
+    /*
+     * @testName: testJsonbAdapterOnCreatorParameter
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.7.1-1
+     *
+     * @test_Strategy: Assert that a record instance has been created with
+     * JsonbCreator and a component annotated with @JsonbTypeAdapter has
+     * been properly deserialized via the adapter.
+     */
     @Test
     public void testJsonbAdapterOnCreatorParameter() {
         CreatorWithAdapterRecord c = jsonb.fromJson("{ \"instance\" : \"string value\" }",

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/RecordInstantiationTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/RecordInstantiationTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbException;
+
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.CreatorPlusFactoryRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.CreatorWithAdapterRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.CreatorWithDeserializerRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.IllegalInstanceFactoryCreatorRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.MultipleCreatorsRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.MultipleFactoryCreatorsRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.SimpleCreatorPlusFieldsRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.SimpleCreatorRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.SimpleCreatorRenameRecord;
+import ee.jakarta.tck.json.bind.customizedmapping.instantiation.model.SimpleFactoryCreatorRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RecordInstantiationTest {
+
+    private final Jsonb jsonb = JsonbBuilder.create();
+
+    /*
+     * @testName: testCustomConstructor
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.5-1
+     *
+     * @test_Strategy: Assert that a constructor annotated with JsonbCreator
+     * annotation can be used to customize record instantiation during
+     * unmarshalling
+     */
+    @Test
+    public void testCustomConstructor() {
+        String toDeserialize = "{ \"stringInstance\" : \"Test String\", \"integerInstance\" : 1, \"floatInstance\" : 1.0 }";
+        SimpleCreatorRecord unmarshalledObject = jsonb.fromJson(toDeserialize, SimpleCreatorRecord.class);
+
+        String validationMessage = "Failed to instantiate record type using JsonbCreator annotated constructor during unmarshalling.";
+        assertThat(validationMessage, unmarshalledObject.stringInstance(), is("Constructor String"));
+        assertThat(validationMessage, unmarshalledObject.integerInstance(), is(2));
+        assertThat(validationMessage, unmarshalledObject.floatInstance(), is(2f));
+    }
+
+    /*
+     * @testName: testFactoryMethodPlusFields
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.5-1
+     *
+     * @test_Strategy: Assert that a static factory method annotated with
+     * JsonbCreator annotation can be used to customize record instantiation
+     * during unmarshalling, with the remaining components defaulted
+     */
+    @Test
+    public void testFactoryMethodPlusFields() {
+        String toDeserialize = "{ \"stringInstance\" : \"Test String\", \"integerInstance\" : 1, \"floatInstance\" : 1.0 }";
+        SimpleCreatorPlusFieldsRecord unmarshalledObject = jsonb.fromJson(toDeserialize, SimpleCreatorPlusFieldsRecord.class);
+
+        String validationMessage = "Failed to instantiate record type using JsonbCreator annotated factory method during unmarshalling.";
+        assertThat(validationMessage, unmarshalledObject.stringInstance(), is("Constructor String"));
+        assertThat(validationMessage, unmarshalledObject.integerInstance(), is(2));
+        assertThat(validationMessage, unmarshalledObject.floatInstance(), is(0f));
+    }
+
+    /*
+     * @testName: testFactoryMethod
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.5-1
+     *
+     * @test_Strategy: Assert that a static factory method annotated with
+     * JsonbCreator annotation can be used to customize record instantiation
+     * during unmarshalling
+     */
+    @Test
+    public void testFactoryMethod() {
+        String toDeserialize = "{ \"constructorString\" : \"Test String\" }";
+        SimpleFactoryCreatorRecord unmarshalledObject = jsonb.fromJson(toDeserialize, SimpleFactoryCreatorRecord.class);
+
+        String validationMessage = "Failed to instantiate record type using JsonbCreator annotated factory method during unmarshalling.";
+        assertThat(validationMessage, unmarshalledObject.stringInstance(), is("Factory String"));
+        assertThat(validationMessage, unmarshalledObject.integerInstance(), is(2));
+        assertThat(validationMessage, unmarshalledObject.floatInstance(), is(3f));
+    }
+
+    /*
+     * @testName: testMultipleConstructors
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.5-1
+     *
+     * @test_Strategy: Assert that a JsonbException is thrown if multiple
+     * constructors of a record are annotated with JsonbCreator annotation
+     */
+    @Test
+    public void testMultipleConstructors() {
+        assertThrows(JsonbException.class,
+                     () -> jsonb.fromJson("{ \"stringInstance\" : \"Test String\", "
+                                                  + "\"integerInstance\" : 1, \"floatInstance\" : 1.0 }",
+                                          MultipleCreatorsRecord.class),
+                     "A JsonbException is expected when unmarshalling to a record with multiple constructors annotated "
+                             + "with JsonbCreator.");
+    }
+
+    /*
+     * @testName: testMultipleFactories
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.5-1
+     *
+     * @test_Strategy: Assert that a JsonbException is thrown if multiple static
+     * factory methods of a record are annotated with JsonbCreator annotation
+     */
+    @Test
+    public void testMultipleFactories() {
+        assertThrows(JsonbException.class,
+                     () -> jsonb.fromJson("{ \"stringInstance\" : \"Test String\", "
+                                                  + "\"integerInstance\" : 1, \"floatInstance\" : 1.0 }",
+                                          MultipleFactoryCreatorsRecord.class),
+                     "A JsonbException is expected when unmarshalling to a record with multiple factory methods annotated "
+                             + "with JsonbCreator.");
+    }
+
+    /*
+     * @testName: testConstructorPlusFactory
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.5-1
+     *
+     * @test_Strategy: Assert that a JsonbException is thrown if multiple
+     * JsonbCreator annotation instances are used to instantiate a record type
+     */
+    @Test
+    public void testConstructorPlusFactory() {
+        assertThrows(JsonbException.class,
+                     () -> jsonb.fromJson("{ \"stringInstance\" : \"Test String\", "
+                                                  + "\"integerInstance\" : 1, \"floatInstance\" : 1.0 }",
+                                          CreatorPlusFactoryRecord.class),
+                     "A JsonbException is expected when unmarshalling to a record with multiple JsonbCreator "
+                             + "annotation instances.");
+    }
+
+    /*
+     * @testName: testIllegalFactoryType
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.5-2
+     *
+     * @test_Strategy: Assert that a JsonbException is thrown if the type returned
+     * by the factory method annotated with JsonbCreator is not the record type
+     * that the annotation is used for
+     */
+    @Test
+    public void testIllegalFactoryType() {
+        assertThrows(JsonbException.class,
+                     () -> jsonb.fromJson("{ \"stringInstance\" : \"Test String\", "
+                                                  + "\"integerInstance\" : 1, \"floatInstance\" : 1.0 }",
+                                          IllegalInstanceFactoryCreatorRecord.class),
+                     "A JsonbException is expected when unmarshalling to a record with a factory method annotated with "
+                             + "JsonbCreator returning a type different than the record type.");
+    }
+
+    /*
+     * @testName: testRenamedProperty
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.5-3
+     *
+     * @test_Strategy: Assert that JsonbProperty annotation can be used to rename
+     * a component of a record constructor annotated as JsonbCreator
+     */
+    @Test
+    public void testRenamedProperty() {
+        String toDeserialize = "{ \"stringInstance\" : \"Test String\", \"intInstance\" : 1, \"floatInstance\" : 1.0 }";
+        SimpleCreatorRenameRecord unmarshalledObject = jsonb.fromJson(toDeserialize, SimpleCreatorRenameRecord.class);
+
+        String validationMessage = "Failed to instantiate record type using JsonbCreator annotated constructor having a JsonbProperty "
+                + "annotated component during unmarshalling.";
+        assertThat(validationMessage, unmarshalledObject.stringInstance(), is("Constructor String"));
+        assertThat(validationMessage, unmarshalledObject.integerInstance(), is(1));
+        assertThat(validationMessage, unmarshalledObject.floatInstance(), is(2f));
+    }
+
+    /*
+     * @testName: testJsonbTypeDeserializerOnCreatorParameter
+     *
+     * @assertion_ids: JSONB:SPEC:JSB-4.7.2-5
+     *
+     * @test_Strategy: Assert that a record instance has been created with
+     * JsonbCreator and a component annotated with @JsonbTypeDeserializer has
+     * been properly deserialized.
+     */
+    @Test
+    public void testJsonbDeserializerOnCreatorParameter() {
+        CreatorWithDeserializerRecord c = jsonb.fromJson("{ \"instance\" : \"Test String\" }",
+                                                         CreatorWithDeserializerRecord.class);
+        String expected = "Test String Deserialized";
+        assertThat("JsonbDeserializer on the JsonbCreator record component was not executed.",
+                   c.stringInstance(), is(expected));
+    }
+
+    @Test
+    public void testJsonbAdapterOnCreatorParameter() {
+        CreatorWithAdapterRecord c = jsonb.fromJson("{ \"instance\" : \"string value\" }",
+                                                    CreatorWithAdapterRecord.class);
+        String expected = "string value";
+        assertThat("JsonbAdapter on the JsonbCreator record component was not executed.", c.stringWrapper(), notNullValue());
+        assertThat("JsonbAdapter on the JsonbCreator record component was not executed.",
+                   expected, is(c.stringWrapper().getWrapped()));
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorPlusFactoryContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorPlusFactoryContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 
 import jakarta.json.bind.annotation.JsonbCreator;
 
+/**
+ * Used to verify a @JsonbCreator annotation on both a static factory method, 
+ * and constructor results in an exception being thrown.
+ */
 public class CreatorPlusFactoryContainer {
     private String stringInstance;
 
@@ -32,6 +36,7 @@ public class CreatorPlusFactoryContainer {
     @JsonbCreator
     public CreatorPlusFactoryContainer(String stringInstance,
                                        Integer integerInstance, float floatInstance) {
+        // supplied values are intentionally ignored for testing
         this.stringInstance = "Constructor String";
         this.integerInstance = 2;
         this.floatInstance = 2;

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorPlusFactoryRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorPlusFactoryRecord.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public record CreatorPlusFactoryRecord(String stringInstance, Integer integerInstance, float floatInstance) {
+
+    @JsonbCreator
+    public CreatorPlusFactoryRecord(
+            @JsonbProperty("stringInstance") String stringInstance,
+            @JsonbProperty("integerInstance") Integer integerInstance,
+            @JsonbProperty("floatInstance") float floatInstance) {
+        this.stringInstance = "Constructor String";
+        this.integerInstance = 2;
+        this.floatInstance = 2f;
+    }
+
+    @JsonbCreator
+    public static CreatorPlusFactoryRecord createInstance(
+            @JsonbProperty("stringInstance") String stringInstance) {
+        return new CreatorPlusFactoryRecord(stringInstance, 3, 3f);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorPlusFactoryRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorPlusFactoryRecord.java
@@ -19,6 +19,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify a @JsonbCreator annotation on both a static factory method, 
+ * and constructor results in an exception being thrown.
+ */
 public record CreatorPlusFactoryRecord(String stringInstance, Integer integerInstance, float floatInstance) {
 
     @JsonbCreator
@@ -26,6 +30,7 @@ public record CreatorPlusFactoryRecord(String stringInstance, Integer integerIns
             @JsonbProperty("stringInstance") String stringInstance,
             @JsonbProperty("integerInstance") Integer integerInstance,
             @JsonbProperty("floatInstance") float floatInstance) {
+        // supplied values are intentionally ignored for testing
         this.stringInstance = "Constructor String";
         this.integerInstance = 2;
         this.floatInstance = 2f;

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithAdapterContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithAdapterContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,10 @@ import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 import jakarta.json.bind.annotation.JsonbTypeAdapter;
 
+/**
+ * Used to verify that an @JsonbTypeAdapter can be used on a parameter of a 
+ * custom constructor used by @JsonbCreator
+ */
 public class CreatorWithAdapterContainer {
 
     private final StringWrapper stringWrapper;

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithAdapterRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithAdapterRecord.java
@@ -21,6 +21,10 @@ import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 import jakarta.json.bind.annotation.JsonbTypeAdapter;
 
+/**
+ * Used to verify that an @JsonbTypeAdapter can be used on a parameter of a 
+ * custom constructor used by @JsonbCreator
+ */
 public record CreatorWithAdapterRecord(StringWrapper stringWrapper) {
 
     @JsonbCreator

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithAdapterRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithAdapterRecord.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.adapter.JsonbAdapter;
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbTypeAdapter;
+
+public record CreatorWithAdapterRecord(StringWrapper stringWrapper) {
+
+    @JsonbCreator
+    public CreatorWithAdapterRecord(
+            @JsonbProperty("instance") @JsonbTypeAdapter(SimpleStringAdapter.class) StringWrapper stringWrapper) {
+        this.stringWrapper = stringWrapper;
+    }
+
+    public static class StringWrapper {
+
+        private final String wrapped;
+
+        private StringWrapper(String wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        public String getWrapped() {
+            return wrapped;
+        }
+    }
+
+    public static class SimpleStringAdapter implements JsonbAdapter<StringWrapper, String> {
+
+        @Override
+        public String adaptToJson(StringWrapper obj) {
+            return obj.getWrapped();
+        }
+
+        @Override
+        public StringWrapper adaptFromJson(String obj) {
+            return new StringWrapper(obj);
+        }
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithDeserializerContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithDeserializerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,6 +29,10 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+/**
+ * Used to verify that an @JsonbTypeDeserializer can be used on a parameter of a 
+ * custom constructor used by @JsonbCreator
+ */
 public class CreatorWithDeserializerContainer {
     private final String stringInstance;
 

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithDeserializerRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithDeserializerRecord.java
@@ -25,6 +25,10 @@ import jakarta.json.bind.serializer.DeserializationContext;
 import jakarta.json.bind.serializer.JsonbDeserializer;
 import jakarta.json.stream.JsonParser;
 
+/**
+ * Used to verify that an @JsonbTypeDeserializer can be used on a parameter of a 
+ * custom constructor used by @JsonbCreator
+ */
 public record CreatorWithDeserializerRecord(String stringInstance) {
 
     @JsonbCreator

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithDeserializerRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/CreatorWithDeserializerRecord.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import java.lang.reflect.Type;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbTypeDeserializer;
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.stream.JsonParser;
+
+public record CreatorWithDeserializerRecord(String stringInstance) {
+
+    @JsonbCreator
+    public CreatorWithDeserializerRecord(
+            @JsonbProperty("instance") @JsonbTypeDeserializer(SimpleStringDeserializer.class) String stringInstance) {
+        this.stringInstance = stringInstance;
+    }
+
+    public static class SimpleStringDeserializer implements JsonbDeserializer<String> {
+
+        public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext, Type type) {
+            if (jsonParser.hasNext()) {
+                JsonParser.Event event = jsonParser.next();
+                if (event != JsonParser.Event.VALUE_STRING) {
+                    throw new IllegalStateException("Unexpected event: " + event);
+                }
+            }
+            return jsonParser.getString() + " Deserialized";
+        }
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/IllegalInstanceFactoryCreatorContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/IllegalInstanceFactoryCreatorContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,11 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 
 import jakarta.json.bind.annotation.JsonbCreator;
 
+/**
+ * Used to verify that a static factory method used by @JsonbCreator
+ * throws an error when returning an instance of type other than 
+ * the class it is defined within.
+ */
 public class IllegalInstanceFactoryCreatorContainer {
     private String stringInstance;
 
@@ -36,6 +41,7 @@ public class IllegalInstanceFactoryCreatorContainer {
     public static SimpleFactoryCreatorContainer createInstance(
             String stringInstance) {
         SimpleFactoryCreatorContainer simpleFactoryCreatorContainer = new SimpleFactoryCreatorContainer();
+        // supplied values are intentionally ignored for testing
         simpleFactoryCreatorContainer.setStringInstance("Factory String");
         simpleFactoryCreatorContainer.setIntegerInstance(2);
         simpleFactoryCreatorContainer.setFloatInstance(3);

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/IllegalInstanceFactoryCreatorRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/IllegalInstanceFactoryCreatorRecord.java
@@ -19,11 +19,17 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify that a static factory method used by @JsonbCreator
+ * throws an error when returning an instance of type other than 
+ * the record it is defined within.
+ */
 public record IllegalInstanceFactoryCreatorRecord(String stringInstance, Integer integerInstance, float floatInstance) {
 
     @JsonbCreator
     public static SimpleCreatorRecord createInstance(
             @JsonbProperty("stringInstance") String stringInstance) {
+        // supplied values are intentionally ignored for testing
         return new SimpleCreatorRecord("Factory String", 2, 3f);
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/IllegalInstanceFactoryCreatorRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/IllegalInstanceFactoryCreatorRecord.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public record IllegalInstanceFactoryCreatorRecord(String stringInstance, Integer integerInstance, float floatInstance) {
+
+    @JsonbCreator
+    public static SimpleCreatorRecord createInstance(
+            @JsonbProperty("stringInstance") String stringInstance) {
+        return new SimpleCreatorRecord("Factory String", 2, 3f);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleCreatorsContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleCreatorsContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 
 import jakarta.json.bind.annotation.JsonbCreator;
 
+/**
+ * Used to verify a @JsonbCreator annotation on multiple
+ * constructors results in an exception being thrown.
+ */
 public class MultipleCreatorsContainer {
     private String stringInstance;
 

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleCreatorsRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleCreatorsRecord.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public record MultipleCreatorsRecord(String stringInstance, Integer integerInstance, float floatInstance) {
+
+    @JsonbCreator
+    public MultipleCreatorsRecord(
+            @JsonbProperty("stringInstance") String stringInstance,
+            @JsonbProperty("integerInstance") Integer integerInstance) {
+        this(stringInstance, integerInstance, 0f);
+    }
+
+    @JsonbCreator
+    public MultipleCreatorsRecord(
+            @JsonbProperty("integerInstance") Integer integerInstance,
+            @JsonbProperty("floatInstance") float floatInstance) {
+        this(null, integerInstance, floatInstance);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleCreatorsRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleCreatorsRecord.java
@@ -19,6 +19,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify a @JsonbCreator annotation on multiple
+ * constructors results in an exception being thrown.
+ */
 public record MultipleCreatorsRecord(String stringInstance, Integer integerInstance, float floatInstance) {
 
     @JsonbCreator

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleFactoryCreatorsContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleFactoryCreatorsContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 
 import jakarta.json.bind.annotation.JsonbCreator;
 
+/**
+ * Used to verify a @JsonbCreator annotation on multiple
+ * static factory methods results in an exception being thrown.
+ */
 public class MultipleFactoryCreatorsContainer {
     private String stringInstance;
 

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleFactoryCreatorsRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleFactoryCreatorsRecord.java
@@ -19,6 +19,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify a @JsonbCreator annotation on multiple
+ * static factory methods results in an exception being thrown.
+ */
 public record MultipleFactoryCreatorsRecord(String stringInstance, Integer integerInstance, float floatInstance) {
 
     @JsonbCreator

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleFactoryCreatorsRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/MultipleFactoryCreatorsRecord.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public record MultipleFactoryCreatorsRecord(String stringInstance, Integer integerInstance, float floatInstance) {
+
+    @JsonbCreator
+    public static MultipleFactoryCreatorsRecord createInstance(
+            @JsonbProperty("stringInstance") String stringInstance,
+            @JsonbProperty("integerInstance") Integer integerInstance) {
+        return new MultipleFactoryCreatorsRecord(stringInstance, integerInstance, 0f);
+    }
+
+    @JsonbCreator
+    public static MultipleFactoryCreatorsRecord createInstance(
+            @JsonbProperty("integerInstance") Integer integerInstance,
+            @JsonbProperty("floatInstance") float floatInstance) {
+        return new MultipleFactoryCreatorsRecord(null, integerInstance, floatInstance);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify that a custom constructor used by @JsonbCreator
+ * can be used to customize fields.
+ */
 public class SimpleCreatorContainer {
     private String stringInstance;
 
@@ -35,6 +39,7 @@ public class SimpleCreatorContainer {
             @JsonbProperty("stringInstance") String stringInstance,
             @JsonbProperty("integerInstance") Integer integerInstance,
             @JsonbProperty("floatInstance") float floatInstance) {
+        // supplied values are intentionally ignored for testing
         this.stringInstance = "Constructor String";
         this.integerInstance = 2;
         this.floatInstance = 2;

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorPlusFieldsContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorPlusFieldsContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,11 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify that a custom constructor used by @JsonbCreator
+ * can be used to customize fields and that primitive fields not 
+ * supplied to the constructor are defaulted based on the specification.
+ */
 public class SimpleCreatorPlusFieldsContainer {
     private String stringInstance;
 
@@ -34,6 +39,7 @@ public class SimpleCreatorPlusFieldsContainer {
     public SimpleCreatorPlusFieldsContainer(
             @JsonbProperty("stringInstance") String stringInstance,
             @JsonbProperty("integerInstance") Integer integerInstance) {
+        // supplied values are intentionally ignored for testing
         this.stringInstance = "Constructor String";
         this.integerInstance = 2;
     }

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorPlusFieldsRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorPlusFieldsRecord.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public record SimpleCreatorPlusFieldsRecord(String stringInstance, Integer integerInstance, float floatInstance) {
+
+    @JsonbCreator
+    public static SimpleCreatorPlusFieldsRecord create(
+            @JsonbProperty("stringInstance") String stringInstance,
+            @JsonbProperty("integerInstance") Integer integerInstance) {
+        return new SimpleCreatorPlusFieldsRecord("Constructor String", 2, 0f);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorPlusFieldsRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorPlusFieldsRecord.java
@@ -19,12 +19,18 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify that a custom constructor used by @JsonbCreator
+ * can be used to customize fields and that primitive fields not 
+ * supplied to the constructor are defaulted based on the specification.
+ */
 public record SimpleCreatorPlusFieldsRecord(String stringInstance, Integer integerInstance, float floatInstance) {
 
     @JsonbCreator
     public static SimpleCreatorPlusFieldsRecord create(
             @JsonbProperty("stringInstance") String stringInstance,
             @JsonbProperty("integerInstance") Integer integerInstance) {
+        // supplied values are intentionally ignored for testing
         return new SimpleCreatorPlusFieldsRecord("Constructor String", 2, 0f);
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRecord.java
@@ -19,6 +19,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify that a custom constructor used by @JsonbCreator
+ * can be used to customize fields.
+ */
 public record SimpleCreatorRecord(String stringInstance, Integer integerInstance, float floatInstance) {
 
     @JsonbCreator
@@ -26,6 +30,7 @@ public record SimpleCreatorRecord(String stringInstance, Integer integerInstance
             @JsonbProperty("stringInstance") String stringInstance,
             @JsonbProperty("integerInstance") Integer integerInstance,
             @JsonbProperty("floatInstance") float floatInstance) {
+        // supplied values are intentionally ignored for testing
         this.stringInstance = "Constructor String";
         this.integerInstance = 2;
         this.floatInstance = 2f;

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRecord.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public record SimpleCreatorRecord(String stringInstance, Integer integerInstance, float floatInstance) {
+
+    @JsonbCreator
+    public SimpleCreatorRecord(
+            @JsonbProperty("stringInstance") String stringInstance,
+            @JsonbProperty("integerInstance") Integer integerInstance,
+            @JsonbProperty("floatInstance") float floatInstance) {
+        this.stringInstance = "Constructor String";
+        this.integerInstance = 2;
+        this.floatInstance = 2f;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRenameContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRenameContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify that a custom constructor used by @JsonbCreator
+ * can utilize @JsonbProperty to rename a parameter name.
+ */
 public class SimpleCreatorRenameContainer {
     private String stringInstance;
 
@@ -35,6 +39,7 @@ public class SimpleCreatorRenameContainer {
             @JsonbProperty("stringInstance") String stringInstance,
             @JsonbProperty("intInstance") Integer integerInstance,
             @JsonbProperty("floatInstance") float floatInstance) {
+        // some supplied values are intentionally ignored for testing
         this.stringInstance = "Constructor String";
         this.integerInstance = integerInstance;
         this.floatInstance = 2;

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRenameRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRenameRecord.java
@@ -19,6 +19,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Used to verify that a custom constructor used by @JsonbCreator
+ * can utilize @JsonbProperty to rename a record component name.
+ */
 public record SimpleCreatorRenameRecord(String stringInstance, Integer integerInstance, float floatInstance) {
 
     @JsonbCreator
@@ -26,6 +30,7 @@ public record SimpleCreatorRenameRecord(String stringInstance, Integer integerIn
             @JsonbProperty("stringInstance") String stringInstance,
             @JsonbProperty("intInstance") Integer integerInstance,
             @JsonbProperty("floatInstance") float floatInstance) {
+        // some supplied values are intentionally ignored for testing
         this.stringInstance = "Constructor String";
         this.integerInstance = integerInstance;
         this.floatInstance = 2f;

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRenameRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleCreatorRenameRecord.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public record SimpleCreatorRenameRecord(String stringInstance, Integer integerInstance, float floatInstance) {
+
+    @JsonbCreator
+    public SimpleCreatorRenameRecord(
+            @JsonbProperty("stringInstance") String stringInstance,
+            @JsonbProperty("intInstance") Integer integerInstance,
+            @JsonbProperty("floatInstance") float floatInstance) {
+        this.stringInstance = "Constructor String";
+        this.integerInstance = integerInstance;
+        this.floatInstance = 2f;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleFactoryCreatorContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleFactoryCreatorContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,10 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Verify that a static factory method used by @JsonbCreator can be used
+ * to customize class instantiation during unmarshalling.
+ */
 public class SimpleFactoryCreatorContainer {
     private String stringInstance;
 
@@ -37,6 +41,7 @@ public class SimpleFactoryCreatorContainer {
     public static SimpleFactoryCreatorContainer createInstance(
             @JsonbProperty("constructorString") String stringInstance) {
         SimpleFactoryCreatorContainer simpleFactoryCreatorContainer = new SimpleFactoryCreatorContainer();
+        // supplied values are intentionally ignored for testing
         simpleFactoryCreatorContainer.setStringInstance("Factory String");
         simpleFactoryCreatorContainer.setIntegerInstance(2);
         simpleFactoryCreatorContainer.setFloatInstance(3);

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleFactoryCreatorRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleFactoryCreatorRecord.java
@@ -19,11 +19,16 @@ package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
 import jakarta.json.bind.annotation.JsonbCreator;
 import jakarta.json.bind.annotation.JsonbProperty;
 
+/**
+ * Verify that a static factory method used by @JsonbCreator can be used
+ * to customize record instantiation during unmarshalling.
+ */
 public record SimpleFactoryCreatorRecord(String stringInstance, Integer integerInstance, float floatInstance) {
 
     @JsonbCreator
     public static SimpleFactoryCreatorRecord createInstance(
             @JsonbProperty("constructorString") String stringInstance) {
+        // supplied values are intentionally ignored for testing
         return new SimpleFactoryCreatorRecord("Factory String", 2, 3f);
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleFactoryCreatorRecord.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/instantiation/model/SimpleFactoryCreatorRecord.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.json.bind.customizedmapping.instantiation.model;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public record SimpleFactoryCreatorRecord(String stringInstance, Integer integerInstance, float floatInstance) {
+
+    @JsonbCreator
+    public static SimpleFactoryCreatorRecord createInstance(
+            @JsonbProperty("constructorString") String stringInstance) {
+        return new SimpleFactoryCreatorRecord("Factory String", 2, 3f);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/defaultmapping/records/RecordInstantiationTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/defaultmapping/records/RecordInstantiationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Eclipse and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -72,3 +72,4 @@ public class RecordInstantiationTest {
     }
 
 }
+

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/defaultmapping/records/RecordInstantiationTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/defaultmapping/records/RecordInstantiationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Eclipse and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package ee.jakarta.tck.json.bind.defaultmapping.records;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RecordInstantiationTest {
+
+    public static record RecordWithCanonicalConstructor(String a, int b) {
+        public RecordWithCanonicalConstructor(String a, int b) {
+            this.a = a.toUpperCase();
+            this.b = b;
+        }
+    }
+
+    public static record RecordWithCompactConstructor(String a, int b) {
+        public RecordWithCompactConstructor {
+            if (b < 0) throw new IllegalArgumentException("b cannot be negative");
+        }
+    }
+
+    private final Jsonb jsonb = JsonbBuilder.create();
+
+    /**
+     * Verify that the overwritten canonical constructor is used 
+     * by asserting that the string is all uppercase.
+     */
+    @Test
+    public void testRecordCanonicalConstructor() {
+        RecordWithCanonicalConstructor result = jsonb.fromJson("{\"a\":\"hello\",\"b\":1}", RecordWithCanonicalConstructor.class);
+        assertThat("Expected canonical constructor to uppercase the string value.",
+                   result.a(), is("HELLO"));
+        assertThat("Expected integer component to be mapped correctly.",
+                   result.b(), is(1));
+    }
+
+    /**
+     * Verify that the compact constructor is used by catching an
+     * expected exception.
+     */
+    @Test
+    public void testRecordCompactConstructor() {
+        assertThrows(JsonbException.class,
+                     () -> jsonb.fromJson("{\"a\":\"hello\",\"b\":-1}", RecordWithCompactConstructor.class),
+                     "Expected a JsonbException when deserializing a record whose compact constructor "
+                             + "throws IllegalArgumentException for a negative value.");
+    }
+
+}

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/defaultmapping/records/RecordsPolymorphicMappingTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/defaultmapping/records/RecordsPolymorphicMappingTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Tests for verification of proper type inheritance handling for records based on annotation with property format.
  */
-public class RecordsPloymorphicMappingTest {
+public class RecordsPolymorphicMappingTest {
 
     private final Jsonb jsonb = JsonbBuilder.create();
 


### PR DESCRIPTION
- standardize language between Javadoc, spec, and userguide
- stop using default constructor, canonical constructor, and compact constructor interchangeably. 
- write tests for default instantiation using canonical constructor and compact constructor for records.
- write tests for customized instantiation using `@JsonbCreator` on records. 