### PR TITLE
feat: standard issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,36 @@
+name: Bug Report
+description: Report a mistake or inconsistency in the specification code or documentation text.
+title: "[Bug]: "
+labels: ["bug"] #Verified - label exists
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > Report a mistake or inconsistency in the specification code, TCK tests, or documentation text.
+        > If error is related to a TCK test after release, then use the TCK Challenge template instead.
+  - type: dropdown
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: Specification Version
+      description: What version of the JSON Bind Spec are you running using?
+      options:
+        - 3.1.0-M1
+        - 3.0.2
+        - 3.0.1
+        - 3.0.0
+        - 2.0.0
+        - 1.0.1
+        - SNAPSHOT (Locally built)
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Bug report
+      placeholder: |
+        > Description of the bug found.
+  - type: textarea
+    attributes:
+      label: Additional information
+      placeholder: "> Proposed solutions, code examples, ect. \n"

--- a/.github/ISSUE_TEMPLATE/certification.yml
+++ b/.github/ISSUE_TEMPLATE/certification.yml
@@ -1,0 +1,97 @@
+name: Platform Certification
+description: Jakarta JSON Bind Platform Certification
+title: "[Certification]: "
+labels: ["certification"] #Verified - label exists
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        > Before submitting a Platform Certification to the Jakarta JSON Bind community please read and be familiar with the 
+        > [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.
+  - type: input
+    id: organization
+    validations:
+      required: true
+    attributes: 
+      label: Organization
+      description: Organization name and URL (if applicable)
+  - type: input
+    id: implementation
+    validations:
+      required: true
+    attributes: 
+      label: Implementation
+      description: Product name, version, and download URL (if applicable)
+  - type: input
+    id: specification
+    validations:
+      required: true
+    attributes: 
+      label: Specification
+      description: Specification name, version, and download URL (if applicable)
+  - type: input
+    id: tck
+    validations:
+      required: true
+    attributes: 
+      label: Technology Compatibility Kit (TCK)
+      description: TCK name, version, and download URL (if applicable)
+  - type: input
+    id: tckSHA
+    validations:
+      required: true
+    attributes: 
+      label: Technology Compatibility Kit (TCK) Validation
+      description: |
+        SHA-256 Checksum
+        This is the checksum of the TCK Distribution zip, not the checksum for the TCK jar artifact.
+        Example: `shasum -a 256 jakarta.jsonb-tck-1.0.0.zip`
+  - type: textarea
+    id: tckResults
+    validations:
+      required: true
+    attributes: 
+      label: Technology Compatibility Kit (TCK) Results
+      description: |
+        Public URL of TCK Results Summary
+        TIP: You can attach TCK Results to this issue by clicking this area to highlight it and then dragging files in.
+  - type: textarea
+    id: additionalRequirements
+    validations:
+      required: true
+    attributes:
+      label: Additional Specification Requirements
+      description: |
+        Specification projects may require additional items for a Certification Request 
+        as defined in their corresponding TCK Documentation under the section labeled "Additional Certification Requirements".
+  - type: textarea
+    id: javaRuntime
+    validations:
+      required: true
+    attributes:
+      label: Java Runtime(s)
+      description: |
+        Java runtime(s) used to run the implementation.
+        Output from `java -version`
+  - type: textarea
+    id: environment
+    validations:
+      required: true
+    attributes:
+      label: Environments
+      description: Summary of the information for the certification environment, operating system, cloud, etc.
+  - type: checkboxes
+    id: ackEFTL
+    attributes:
+      label: Eclipse Foundation Technology Compatibility Kit License (EFTL)
+      description: Do you accept the terms of the (EFTL)?
+      options:
+      - label: By checking this box I acknowledge that the organization I represent accepts the terms of the [EFTL](https://www.eclipse.org/legal/tck.php)
+        required: true
+  - type: checkboxes
+    id: ackRules
+    attributes:
+      label: TCK Requirements and Compatibility
+      options:
+      - label: By checking this box I attest that all TCK requirements have been met, including any compatibility rules.
+        required: true

--- a/.github/ISSUE_TEMPLATE/clarification.yml
+++ b/.github/ISSUE_TEMPLATE/clarification.yml
@@ -1,0 +1,30 @@
+name: Clarification
+description: Request that some aspect of the specification be clarified. 
+title: "[clarification]: "
+labels: ["question"] #Verified - label exists
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        > Request that some aspect of the specification be clarified.
+  - type: input
+    id: specification
+    validations:
+      required: true
+    attributes: 
+      label: Specification
+      description: What specification / api is the clarification related to? Provide a link to the API class or SPEC document section. 
+      placeholder: |
+        ex. [Jsonb](https://github.com/jakartaee/jsonb-api/blob/main/api/src/main/java/jakarta/json/bind/Jsonb.java#L129)
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: I need clarification on ...
+      placeholder: |
+        > Description of the clarification needed.
+  - type: textarea
+    attributes:
+      label: Additional information
+      placeholder: |
+        > Proposed solutions, code examples, ect. 

--- a/.github/ISSUE_TEMPLATE/tck-challenge.yml
+++ b/.github/ISSUE_TEMPLATE/tck-challenge.yml
@@ -1,0 +1,88 @@
+name: TCK Challenge
+description: Jakarta JSON Bind TCK Challenge
+title: "[TCK Challenge]: "
+labels: ["challenge"] #Verified - label exists
+body:
+  - type: markdown
+    attributes:
+      value: "> Before submitting a TCK Challenge to the Jakarta JSON Bind community please read and be familiar with the \n> [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.\n"
+  - type: input
+    id: specification
+    validations:
+      required: true
+    attributes:
+      label: Specification
+      description: What specification is the challenge related to? Provide a link to the specification class or document section.
+      placeholder: |
+        ex. [fromJson method](https://github.com/jakartaee/jsonb-api/blob/main/api/src/main/java/jakarta/json/bind/Jsonb.java#L129)
+  - type: input
+    id: assertion
+    validations:
+      required: true
+    attributes:
+      label: Assertion
+      description: What assertion is the challenge related to? Provide a link to the assertion description
+      placeholder: |
+        ex. [Annotation tests](https://github.com/jakartaee/jsonb-api/blob/main/tck/src/main/java/ee/jakarta/tck/json/bind/api/annotation/AnnotationTest.java#L62)
+  - type: dropdown
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: TCK Version
+      description: What version of the TCK are you running against?
+      options:
+        - 3.1.0-M1
+        - 3.0.2
+        - 3.0.1
+        - 3.0.0
+        - 2.0.0
+        - 1.0.1
+        - SNAPSHOT (Locally built)
+  - type: input
+    id: implementation
+    validations:
+      required: true
+    attributes:
+      label: Implementation being tested
+      description: What implementation is being tested? Include name of company/organization
+      placeholder: |
+        ex. Open Liberty / IBM
+  - type: dropdown
+    id: challengeType
+    validations:
+      required: true
+    attributes:
+      label: Challenge Scenario
+      description: Which of the following scenarios best match this challenge?
+      options:
+        - Claims that a test assertion conflicts with the specification.
+        - Claims that a test asserts requirements over and above that of the specification.
+        - Claims that an assertion of the specification is not sufficiently implementable.
+        - Claims that a test is not portable or depends on a particular implementation.
+        - Something else
+  - type: textarea
+    id: fullDescription
+    validations:
+      required: true
+    attributes:
+      label: Full Description
+      description: |
+        Describe the challenge in full detail including logs.
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      placeholder: |
+        > Description of issue using markdown syntax
+  - type: textarea
+    id: additionalContext
+    attributes:
+      label: Additional Context
+      description: Additional context about the problem, possible solutions, alternative interpretations, etc.
+  - type: checkboxes
+    attributes:
+      label: Is there an existing challenge for this?
+      description: |
+        Please search to see if a challenge already exists, or has been approved, that matches your challenge.
+        https://github.com/jakartaee/jsonb-api/issues?q=sort%3Aupdated-desc%20is%3Aissue%20label%3Achallenge
+      options:
+        - label: I have searched the existing issues
+          required: true

--- a/.github/ISSUE_TEMPLATE/use-case.yml
+++ b/.github/ISSUE_TEMPLATE/use-case.yml
@@ -1,0 +1,36 @@
+name: Use Case
+description: Describe a new use case for the specification. 
+title: "[Use Case]: "
+labels: ["enhancement"] #Verified - label exists
+body:
+  - type: markdown
+    attributes: 
+      value: |
+        > Describe a new use case for the specification.
+  - type: checkboxes
+    attributes:
+      label: As a ...
+      options:
+      - label: Application user/user of the configuration itself
+      - label: API user (application developer)
+      - label: SPI user (container or runtime developer)
+      - label: Specification implementer
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: I need to be able to ...
+      placeholder: |
+        > Description of the new or different use case
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Which enables me to ...
+      placeholder: |
+        > Description of the added value of this use case
+  - type: textarea
+    attributes:
+      label: Additional information
+      placeholder: |
+        > Proposed solutions, code examples, ect. 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+# This workflow will run when a release is created, and automatically update GitHub issue templates
+
+name: GitHub Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: 'main' # Otherwise, this action will checkout the tag that was created during publishing
+    - name: Create branch
+      id: checkout
+      run: .github/scripts/checkout.sh update-templates-${{ github.sha }}
+    - name: Insert release - ${{ github.event.release.tag_name }}
+      uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d #v4.53.3
+      with:
+        cmd: |
+            yq -i '( .body.[] | select(.id == "version") ) ref $x | $x .attributes.options = ["${{ github.event.release.tag_name }}"] + $x .attributes.options' .github/ISSUE_TEMPLATE/bug-report.yml &&
+            yq -i '( .body.[] | select(.id == "version") ) ref $x | $x .attributes.options = ["${{ github.event.release.tag_name }}"] + $x .attributes.options' .github/ISSUE_TEMPLATE/tck-challenge.yml
+    - name: Needs updates
+      id: update
+      run: echo "update_count=$(git status -s -uno | wc -l)" >> $GITHUB_OUTPUT
+    - name: Create commit
+      if: steps.update.outputs.update_count > 0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+
+        git add .github/ISSUE_TEMPLATE/bug-report.yml
+        git add .github/ISSUE_TEMPLATE/tck-challenge.yml
+
+        git commit -m "Update templates to include release ${{ github.event.release.tag_name }}"
+        git push origin update-templates-${{ github.sha }}
+
+  pull-request:
+    needs: [update]
+    uses: ./.github/workflows/pull-request.yml
+    with:
+      branch: 'update-templates-${{ github.sha }}'
+      title: 'Update templates to include release ${{ github.event.release.tag_name }}'
+      body: 'generated pull request'


### PR DESCRIPTION
Add in the standard set of issue templates used by all the other Jakarta EE projects. 
This way things like challenges will automatically get the `challenge` tag and not be missed or mislabeled.

Include: 
- bug reports
- certifications
- questions
- TCK challenges
- use cases

Fixes https://github.com/jakartaee/jsonb-api/pull/359