### PR TITLE
challenge: skip test testCreatorDeserialization

### DIFF
--- a/tck-docs/TCK-Exclude-List.txt
+++ b/tck-docs/TCK-Exclude-List.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2026 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,4 +30,9 @@ jakarta/jsonb/bind/tck/defaultmapping/dates/DatesMappingTest.java#testGregorianC
 #
 jakarta/jsonb/bind/tck/defaultmapping/collections/CollectionsMappingTest.java#testEnumMap_from_standalone
 jakarta/jsonb/bind/tck/defaultmapping/collections/CollectionsMappingTest.java#testEnumSet_from_standalone
+
+#
+# Bug ID: https://github.com/jakartaee/jsonb-api/issues/347
+#
+ee/jakarta/tck/json/bind/defaultmapping/polymorphictypes/AnnotationTypeInfoTest.java#testCreatorDeserialization
 

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/defaultmapping/polymorphictypes/AnnotationTypeInfoTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/defaultmapping/polymorphictypes/AnnotationTypeInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,6 +27,7 @@ import jakarta.json.bind.annotation.JsonbProperty;
 import jakarta.json.bind.annotation.JsonbSubtype;
 import jakarta.json.bind.annotation.JsonbTypeInfo;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -79,6 +80,7 @@ public class AnnotationTypeInfoTest {
     }
 
     @Test
+    @Disabled("See: https://github.com/jakartaee/jsonb-api/issues/347")
     public void testCreatorDeserialization() {
         SomeDateType deserialized = jsonb.fromJson("{\"@dateType\":\"constructor\",\"localDate\":\"26-02-2021\"}",
                                                    SomeDateType.class);


### PR DESCRIPTION
Parent: #347 

Disables this test in the downstream TCK because the behavior asserted by the test is ambiguous in the API and Spec.