### PR TITLE
Fix tests that make wrong assumptions about char encoding 3.0

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/json/bind/SimpleMappingTester.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/SimpleMappingTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
@@ -65,14 +66,14 @@ public class SimpleMappingTester<T> {
     }
 
     private void testMarshalling(T value, String expectedRepresentation) {
-        String jsonString = jsonb.toJson(value);
+        String jsonString = jsonb.toJson(value); // Assumes character encoding is Default when creating Writer
         assertThat("[testMarshalling] - Failed to correctly marshal " + value.getClass().getName() + " object",
                    jsonString, matchesPattern(expectedRepresentation));
     }
 
     private void testMarshallingToStream(T value, String expectedRepresentation) {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            jsonb.toJson(value, stream);
+            jsonb.toJson(value, stream); // Assumes character encoding is UTF-8 when creating Writer
             String jsonString = new String(stream.toByteArray(), StandardCharsets.UTF_8);
             assertThat("[testMarshallingToStream] - Failed to correctly marshal " + value.getClass().getName() + " object",
                        jsonString, matchesPattern(expectedRepresentation));
@@ -84,8 +85,8 @@ public class SimpleMappingTester<T> {
     private void testMarshallingToWriter(T value, String expectedRepresentation) {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 OutputStreamWriter writer = new OutputStreamWriter(stream)) {
-            jsonb.toJson(value, writer);
-            String jsonString = new String(stream.toByteArray(), StandardCharsets.UTF_8);
+            jsonb.toJson(value, writer); // Writer determins character encoding (Default)
+            String jsonString = new String(stream.toByteArray(), Charset.defaultCharset());
             assertThat("[testMarshallingToWriter] - Failed to correctly marshal " + value.getClass().getName() + " object",
                        jsonString, matchesPattern(expectedRepresentation));
         } catch (IOException e) {
@@ -94,14 +95,14 @@ public class SimpleMappingTester<T> {
     }
 
     private void testMarshallingByType(T value, String expectedRepresentation) {
-        String jsonString = jsonb.toJson(value, serializationType);
+        String jsonString = jsonb.toJson(value, serializationType); // Assumes character encoding is Default when creating Writer
         assertThat("[testMarshallingByType] - Failed to correctly marshal " + value.getClass().getName() + " object",
                    jsonString, matchesPattern(expectedRepresentation));
     }
 
     private void testMarshallingByTypeToStream(T value, String expectedRepresentation) {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            jsonb.toJson(value, serializationType, stream);
+            jsonb.toJson(value, serializationType, stream); // Assumes character encoding is UTF-8 when creating Writer
             String jsonString = new String(stream.toByteArray(), StandardCharsets.UTF_8);
             assertThat("[testMarshallingByTypeToStream] - Failed to correctly marshal " + value.getClass().getName() + " object",
                        jsonString, matchesPattern(expectedRepresentation));
@@ -113,8 +114,8 @@ public class SimpleMappingTester<T> {
     private void testMarshallingByTypeToWriter(T value, String expectedRepresentation) {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 OutputStreamWriter writer = new OutputStreamWriter(stream)) {
-            jsonb.toJson(value, serializationType, writer);
-            String jsonString = new String(stream.toByteArray(), StandardCharsets.UTF_8);
+            jsonb.toJson(value, serializationType, writer); // Writer determins character encoding (Default)
+            String jsonString = new String(stream.toByteArray(), Charset.defaultCharset());
             assertThat("[testMarshallingByTypeToWriter] - Failed to correctly marshal " + value.getClass().getName() + " object",
                        jsonString, matchesPattern(expectedRepresentation));
         } catch (IOException e) {
@@ -123,14 +124,14 @@ public class SimpleMappingTester<T> {
     }
 
     private void testUnmarshallingByClass(String expectedRepresentation, Object value) {
-        Object unmarshalledObject = jsonb.fromJson(expectedRepresentation, typeClass);
+        Object unmarshalledObject = jsonb.fromJson(expectedRepresentation, typeClass); // Assumes character encoding is Default when creating Reader
         assertThat("[testUnmarshallingByClass] - Failed to correctly unmarshal " + value.getClass().getName() + " object",
                    unmarshalledObject, is(value));
     }
 
     private void testUnmarshallingByClassFromStream(String expectedRepresentation, Object value) {
         try (ByteArrayInputStream stream = new ByteArrayInputStream(expectedRepresentation.getBytes(StandardCharsets.UTF_8))) {
-            Object unmarshalledObject = jsonb.fromJson(stream, typeClass);
+            Object unmarshalledObject = jsonb.fromJson(stream, typeClass); // Assumes character encoding is UTF-8 when creating Reader
             assertThat("[testUnmarshallingByClassFromStream] - Failed to correctly unmarshal " + value.getClass()
                                .getName() + " object",
                        unmarshalledObject, is(value));
@@ -140,9 +141,9 @@ public class SimpleMappingTester<T> {
     }
 
     private void testUnmarshallingByClassFromReader(String expectedRepresentation, Object value) {
-        try (ByteArrayInputStream stream = new ByteArrayInputStream(expectedRepresentation.getBytes(StandardCharsets.UTF_8));
+        try (ByteArrayInputStream stream = new ByteArrayInputStream(expectedRepresentation.getBytes());
                 InputStreamReader reader = new InputStreamReader(stream)) {
-            Object unmarshalledObject = jsonb.fromJson(reader, typeClass);
+            Object unmarshalledObject = jsonb.fromJson(reader, typeClass); // Reader determins character encoding (Default)
             assertThat("[testUnmarshallingByClassFromReader] - Failed to correctly unmarshal " + value.getClass()
                                .getName() + " object",
                        unmarshalledObject, is(value));
@@ -152,14 +153,14 @@ public class SimpleMappingTester<T> {
     }
 
     private void testUnmarshallingByType(String expectedRepresentation, Object value) {
-        Object unmarshalledObject = jsonb.fromJson(expectedRepresentation, (Type) typeClass);
+        Object unmarshalledObject = jsonb.fromJson(expectedRepresentation, (Type) typeClass); // Assumes character encoding is Default when creating Writer
         assertThat("[testUnmarshallingByType] - Failed to correctly unmarshal " + value.getClass().getName() + " object",
                    unmarshalledObject, is(value));
     }
 
     private void testUnmarshallingByTypeFromStream(String expectedRepresentation, Object value) {
         try (ByteArrayInputStream stream = new ByteArrayInputStream(expectedRepresentation.getBytes(StandardCharsets.UTF_8))) {
-            Object unmarshalledObject = jsonb.fromJson(stream, (Type) typeClass);
+            Object unmarshalledObject = jsonb.fromJson(stream, (Type) typeClass); // Assumes character encoding is UTF-8 when creating Writer
             assertThat("[testUnmarshallingByTypeFromStream] - Failed to correctly unmarshal " + value.getClass()
                                .getName() + " object",
                        unmarshalledObject, is(value));
@@ -169,9 +170,9 @@ public class SimpleMappingTester<T> {
     }
 
     private void testUnmarshallingByTypeFromReader(String expectedRepresentation, Object value) {
-        try (ByteArrayInputStream stream = new ByteArrayInputStream(expectedRepresentation.getBytes(StandardCharsets.UTF_8));
+        try (ByteArrayInputStream stream = new ByteArrayInputStream(expectedRepresentation.getBytes());
                 InputStreamReader reader = new InputStreamReader(stream)) {
-            Object unmarshalledObject = jsonb.fromJson(reader, (Type) typeClass);
+            Object unmarshalledObject = jsonb.fromJson(reader, (Type) typeClass);  // Reader determins character encoding (Default)
             assertThat("[testUnmarshallingByTypeFromReader] - Failed to correctly unmarshal " + value.getClass()
                                .getName() + " object",
                        unmarshalledObject, is(value));

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/SimpleMappingTester.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/SimpleMappingTester.java
@@ -85,7 +85,7 @@ public class SimpleMappingTester<T> {
     private void testMarshallingToWriter(T value, String expectedRepresentation) {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 OutputStreamWriter writer = new OutputStreamWriter(stream)) {
-            jsonb.toJson(value, writer); // Writer determins character encoding (Default)
+            jsonb.toJson(value, writer); // Writer determines character encoding (Default)
             String jsonString = new String(stream.toByteArray(), Charset.defaultCharset());
             assertThat("[testMarshallingToWriter] - Failed to correctly marshal " + value.getClass().getName() + " object",
                        jsonString, matchesPattern(expectedRepresentation));
@@ -114,7 +114,7 @@ public class SimpleMappingTester<T> {
     private void testMarshallingByTypeToWriter(T value, String expectedRepresentation) {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 OutputStreamWriter writer = new OutputStreamWriter(stream)) {
-            jsonb.toJson(value, serializationType, writer); // Writer determins character encoding (Default)
+            jsonb.toJson(value, serializationType, writer); // Writer determines character encoding (Default)
             String jsonString = new String(stream.toByteArray(), Charset.defaultCharset());
             assertThat("[testMarshallingByTypeToWriter] - Failed to correctly marshal " + value.getClass().getName() + " object",
                        jsonString, matchesPattern(expectedRepresentation));
@@ -143,7 +143,7 @@ public class SimpleMappingTester<T> {
     private void testUnmarshallingByClassFromReader(String expectedRepresentation, Object value) {
         try (ByteArrayInputStream stream = new ByteArrayInputStream(expectedRepresentation.getBytes());
                 InputStreamReader reader = new InputStreamReader(stream)) {
-            Object unmarshalledObject = jsonb.fromJson(reader, typeClass); // Reader determins character encoding (Default)
+            Object unmarshalledObject = jsonb.fromJson(reader, typeClass); // Reader determines character encoding (Default)
             assertThat("[testUnmarshallingByClassFromReader] - Failed to correctly unmarshal " + value.getClass()
                                .getName() + " object",
                        unmarshalledObject, is(value));
@@ -172,7 +172,7 @@ public class SimpleMappingTester<T> {
     private void testUnmarshallingByTypeFromReader(String expectedRepresentation, Object value) {
         try (ByteArrayInputStream stream = new ByteArrayInputStream(expectedRepresentation.getBytes());
                 InputStreamReader reader = new InputStreamReader(stream)) {
-            Object unmarshalledObject = jsonb.fromJson(reader, (Type) typeClass);  // Reader determins character encoding (Default)
+            Object unmarshalledObject = jsonb.fromJson(reader, (Type) typeClass);  // Reader determines character encoding (Default)
             assertThat("[testUnmarshallingByTypeFromReader] - Failed to correctly unmarshal " + value.getClass()
                                .getName() + " object",
                        unmarshalledObject, is(value));

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/api/jsonb/JsonbTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/api/jsonb/JsonbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.json.bind.Jsonb;
@@ -94,7 +95,7 @@ public class JsonbTest {
     @Test
     public void testFromJsonReaderClass() throws IOException {
         try (ByteArrayInputStream stream = new ByteArrayInputStream(TEST_JSON_BYTE);
-                InputStreamReader reader = new InputStreamReader(stream)) {
+                InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) { //TEST_JSON uses UTF-8
             SimpleContainer unmarshalledObject = jsonb.fromJson(reader, SimpleContainer.class);
             assertThat("Failed to unmarshal using Jsonb.fromJson method with Reader and Class arguments.",
                        unmarshalledObject.getInstance(), is(TEST_STRING));
@@ -112,7 +113,7 @@ public class JsonbTest {
     @Test
     public void testFromJsonReaderType() throws IOException {
         try (ByteArrayInputStream stream = new ByteArrayInputStream(TEST_JSON_BYTE);
-                InputStreamReader reader = new InputStreamReader(stream)) {
+                InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) { //TEST_JSON uses UTF-8
             SimpleContainer unmarshalledObject = jsonb
                     .fromJson(reader, new SimpleContainer() { }.getClass().getGenericSuperclass());
             assertThat("Failed to unmarshal using Jsonb.fromJson method with Reader and Type arguments.",
@@ -198,7 +199,7 @@ public class JsonbTest {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 OutputStreamWriter writer = new OutputStreamWriter(stream)) {
             jsonb.toJson(new SimpleContainer(), writer);
-            String jsonString = new String(stream.toByteArray(), StandardCharsets.UTF_8);
+            String jsonString = new String(stream.toByteArray(), Charset.defaultCharset()); //Writer uses Default
             assertThat("Failed to marshal using Jsonb.toJson method with Object and Writer arguments.",
                        jsonString, matchesPattern(MATCHING_PATTERN));
         }
@@ -217,7 +218,7 @@ public class JsonbTest {
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 OutputStreamWriter writer = new OutputStreamWriter(stream)) {
             jsonb.toJson(new SimpleContainer(), new SimpleContainer() { }.getClass().getGenericSuperclass(), writer);
-            String jsonString = new String(stream.toByteArray(), StandardCharsets.UTF_8);
+            String jsonString = new String(stream.toByteArray(), Charset.defaultCharset()); //Writer uses Default
             assertThat("Failed to marshal using Jsonb.toJson method with Object, Type and Writer arguments.",
                        jsonString, matchesPattern(MATCHING_PATTERN));
         }

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/binarydata/BinaryDataCustomizationTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/binarydata/BinaryDataCustomizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,6 +32,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * @test
  * @sources BinaryDataCustomizationTest.java
@@ -60,7 +62,7 @@ public class BinaryDataCustomizationTest {
         BinaryDataContainer container = jsonb.fromJson("{ \"data\" : [ 84, 101, 115, 116, 32, 83, 116, 114, 105, 110, 103 ] }",
                                                        BinaryDataContainer.class);
         assertThat("Failed to correctly unmarshal binary data using BYTE binary data encoding.",
-                   new String(container.getData()), is("Test String"));
+                   new String(container.getData(), StandardCharsets.UTF_8), is("Test String")); //Data was encoded using UTF-8
     }
 
     /*
@@ -81,7 +83,7 @@ public class BinaryDataCustomizationTest {
 
         BinaryDataContainer unmarshalledObject = jsonb.fromJson("{ \"data\" : \"VGVzdCBTdHJpbmc\" }", BinaryDataContainer.class);
         assertThat("Failed to correctly unmarshal binary data using BASE_64 binary data encoding.",
-                   new String(unmarshalledObject.getData()), is("Test String"));
+                   new String(unmarshalledObject.getData(), StandardCharsets.UTF_8), is("Test String")); //Data was encoded using UTF-8
     }
 
     /*
@@ -102,6 +104,6 @@ public class BinaryDataCustomizationTest {
 
         BinaryDataContainer unmarshalledObject = jsonb.fromJson("{ \"data\" : \"VGVzdCBTdHJpbmc=\" }", BinaryDataContainer.class);
         assertThat("Failed to correctly unmarshal binary data using BASE_64_URL binary data encoding.",
-                   new String(unmarshalledObject.getData()), is("Test String"));
+                   new String(unmarshalledObject.getData(), StandardCharsets.UTF_8), is("Test String")); //Data was encoded using UTF-8
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/binarydata/model/BinaryDataContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/binarydata/model/BinaryDataContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,10 @@
 
 package ee.jakarta.tck.json.bind.customizedmapping.binarydata.model;
 
+import java.nio.charset.StandardCharsets;
+
 public class BinaryDataContainer {
-    private byte[] data = "Test String".getBytes();
+    private byte[] data = "Test String".getBytes(StandardCharsets.UTF_8); // Data must be UTF-8 for assertions
 
     public byte[] getData() {
         return data;

--- a/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/ijson/model/BinaryDataContainer.java
+++ b/tck/src/main/java/ee/jakarta/tck/json/bind/customizedmapping/ijson/model/BinaryDataContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,8 +20,10 @@
 
 package ee.jakarta.tck.json.bind.customizedmapping.ijson.model;
 
+import java.nio.charset.StandardCharsets;
+
 public class BinaryDataContainer {
-    private byte[] data = "Test String".getBytes();
+    private byte[] data = "Test String".getBytes(StandardCharsets.UTF_8); // Data must be UTF-8 for assertions
 
     public byte[] getData() {
         return data;


### PR DESCRIPTION
Fixes https://github.com/jakartaee/jsonb-api/issues/348
Applies https://github.com/jakartaee/jsonb-api/pull/349 to downstream branch 3.0.2