### PR TITLE
fix: OSGi yasson in 3.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -223,7 +223,14 @@
                             <Specification-Version>${spec.specification.version}</Specification-Version>
                             <Specification-Vendor>${vendor.name}</Specification-Vendor>
                             <_nodefaultversion>false</_nodefaultversion>
-                            <Export-Package>jakarta.json.bind.*; version=${spec.version}</Export-Package>
+                            <Export-Package>
+                                jakarta.json.bind.*; version=${spec.version}
+                            </Export-Package>
+                            <!-- Avoid BND package scanner picking up string literal as a package -->
+                            <Import-Package>
+                                !org.eclipse.yasson,
+                                *
+                            </Import-Package>
                             <_noee>true</_noee>
                         </instructions>
                     </configuration>

--- a/tck-docs/userguide/pom.xml
+++ b/tck-docs/userguide/pom.xml
@@ -185,24 +185,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-scm-publish-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>deploy-site</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>publish-scm</goal>
-                        </goals>
-                        <configuration>
-                            <scmBranch>gh-pages</scmBranch>
-                            <skipDeletedFiles>false</skipDeletedFiles>
-                            <checkinComment>Update site</checkinComment>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
 	    </plugins>
 
         <pluginManagement>
@@ -226,11 +208,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.3.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jbake</groupId>


### PR DESCRIPTION
- backport fix to 3.0 branch
- disable tck user guide publishing from the 3.0 branch 
  - replaced with a github actions build 