### PR TITLE
Javadoc for main landing page, jakarta.json.bind package page, and review Jsonb class

### DIFF
--- a/api/src/main/java/jakarta/json/bind/Jsonb.java
+++ b/api/src/main/java/jakarta/json/bind/Jsonb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,85 +23,95 @@ import java.io.Writer;
 import java.lang.reflect.Type;
 
 /**
+ * <p>Converts Java objects to and from JSON documents.
+ *
  * <p>{@code Jsonb} provides an abstraction over the JSON Binding framework operations:</p>
  *
  * <ul>
- * <li>{@code fromJson}: read JSON input, deserialize to Java objects content tree
- * <li>{@code toJson}: serialize Java objects content tree to JSON input
+ * <li>{@code fromJson}: reads JSON input, deserializes to a Java objects content tree
+ * <li>{@code toJson}: serializes a Java objects content tree to JSON output
  * </ul>
  *
- * <p>Instance of this class is created using {@link jakarta.json.bind.JsonbBuilder JsonbBuilder}
- * builder methods:</p>
+ * <p>An instance of this class is created using a {@link JsonbBuilder}
+ * builder method:</p>
  * <pre>{@code
  * // Example 1 - Creating Jsonb using default JsonbBuilder instance provided by default JsonbProvider
  * Jsonb jsonb = JsonbBuilder.create();
  *
  * // Example 2 - Creating Jsonb instance for a specific provider specified by a class name
- * Jsonb jsonb = JsonbBuilder.newBuilder("foo.bar.ProviderImpl).build();
+ * Jsonb jsonb = JsonbBuilder.newBuilder("foo.bar.ProviderImpl").build();
  *
  * // Example 3 - Creating Jsonb instance from a custom provider implementation
  * Jsonb jsonb = new CustomJsonbBuilder().build();
  * }</pre>
  *
- * <b>Deserializing (reading) JSON</b><br>
- * <blockquote>
- * Can de-serialize JSON data that represents either an entire JSON
+ * <h2>Deserializing (reading) JSON</h2>
+ *
+ * <p>You can deserialize JSON data that represents either an entire JSON
  * document or a subtree of a JSON document.
- * </blockquote>
- * <blockquote>
- * Reading (deserializing) object content tree from a File:<br><br>
- *    <pre>
- *     Jsonb jsonb = JsonbBuilder.create();
- *     Book book = jsonb.fromJson(new FileReader("jsonfile.json"), Book.class);</pre>
- * If the deserialization process is unable to deserialize the JSON content to an object
- * content tree, fatal error is reported that terminates processing by
- * throwing JsonbException.
- * </blockquote>
  *
- * <p><b>Serializing (writing) to JSON</b></p>
- * <blockquote>
- * Serialization writes the representation of a Java object content tree into
- * JSON data.
- * </blockquote>
- * <blockquote>
- * Writing (serializing) object content tree to a File:<br><br>
- *    <pre>
- *     jsonb.toJson(object, new FileWriter("foo.json"));</pre>
- * Writing (serializing) to a Writer:<br><br>
- *    <pre>
- *     jsonb.toJson(object, new PrintWriter(System.out));
- *    </pre>
- * </blockquote>
+ * <p>Reading (deserializing) an object content tree from a file:
+ * <pre>{@code
+ *   Jsonb jsonb = JsonbBuilder.create();
+ *   try (FileReader reader = new FileReader("jsonfile.json")) {
+ *       Book book = jsonb.fromJson(reader, Book.class);
+ *   }
+ * }</pre>
  *
- * <p><b>Encoding</b></p>
- * <blockquote>
- * In deserialization operations ({@code fromJson}), encoding of JSON data is detected automatically.
- * Use the {@link jakarta.json.bind.JsonbConfig JsonbConfig} API to configure expected
- * input encoding used within deserialization operations. Client applications are
- * expected to supply a valid character encoding as defined in the
- * <a href="http://tools.ietf.org/html/rfc7159">RFC 7159</a> and supported by Java Platform.
+ * <p>If the deserialization process is unable to deserialize the JSON content to an object
+ * content tree, a fatal error is reported that terminates processing by
+ * throwing {@link JsonbException}.
  *
- * In serialization operations ({@code toJson}), UTF-8 encoding is used by default
- * for writing JSON data.
- * Use the {@link jakarta.json.bind.JsonbConfig JsonbConfig} API to configure the
- * output encoding used within serialization operations. Client applications are
- * expected to supply a valid character encoding as defined in the
- * <a href="http://tools.ietf.org/html/rfc7159">RFC 7159</a> and supported by Java Platform.
- * </blockquote>
+ * <h2>Serializing (writing) to JSON</h2>
  *
- * <p>For optimal use, {@code JsonbBuilder} and {@code Jsonb} instances should be
- * reused - for a typical use-case, only one {@code Jsonb} instance is
- * required by an application.</p>
+ * <p>Serialization writes the representation of a Java object content tree into
+ * JSON data.</p>
  *
- * <p>All the methods in this class are safe for use by multiple concurrent threads.</p>
+ * <p>Writing (serializing) an object content tree to a file:</p>
+ * <pre>{@code
+ *   try (FileWriter writer = new FileWriter("foo.json")) {
+ *       jsonb.toJson(object, writer);
+ *   }
+ * }</pre>
  *
- * <p>Calling {@code Closable.close()} method will cleanup all CDI managed components
- * (such as adapters with CDI dependencies) created during interaction with Jsonb.
- * Calling {@code close()} must be done after all threads has finished interaction with Jsonb.
- * If there are remaining threads working with Jsonb and {@code close()} is called, behaviour is undefined.
- * </p>
+ * <p>Writing (serializing) to a {@link java.io.Writer Writer}:</p>
+ * <pre>{@code
+ *   PrintWriter writer = new PrintWriter(System.out);
+ *   jsonb.toJson(object, writer);
+ *   writer.flush();
+ * }</pre>
  *
- * @see Jsonb
+ * <h2>Encoding</h2>
+ *
+ * <p>In deserialization operations ({@code fromJson}), encoding of JSON data
+ * is detected automatically. You can use the {@link JsonbConfig} API to
+ * manually configure the input encoding for deserialization operations.
+ * Applications must supply a valid character encoding as defined in the
+ * <a href="http://tools.ietf.org/html/rfc7159">RFC 7159</a> and which is
+ * also supported by the Java Platform.
+ *
+ * <p>In serialization operations ({@code toJson}), UTF-8 encoding is used
+ * by default for writing JSON data.
+ * Use the {@link JsonbConfig} API to configure the
+ * output encoding for serialization operations. Applications must supply
+ * a valid character encoding as defined in the
+ * <a href="http://tools.ietf.org/html/rfc7159">RFC 7159</a> and which is
+ * also supported by Java Platform.
+ *
+ * <p>For optimal performance, reuse {@code JsonbBuilder} and {@code Jsonb}
+ * instances. For a typical use-case, only one {@code Jsonb} instance is
+ * required by an application.
+ *
+ * <p>All the methods in this class are safe for concurrent use by multiple
+ * threads.
+ *
+ * <p>Calling the {@link #close()} method cleans up all CDI managed components
+ * (such as adapters with CDI dependencies) created during interaction with
+ * the respective {@code Jsonb} instance. Calling {@code close()} must be done
+ * after all threads have finished interaction with the {@code Jsonb} instance.
+ * If there are remaining threads working with the {@code Jsonb} instance and
+ * {@code close()} is called, behaviour is undefined.
+ *
  * @see JsonbBuilder
  * @see java.util.ServiceLoader
  * @since JSON Binding 1.0
@@ -109,7 +119,7 @@ import java.lang.reflect.Type;
 public interface Jsonb extends AutoCloseable {
 
     /**
-     * Reads in a JSON data from the specified string and return the resulting
+     * Reads JSON data from the specified string and returns the resulting
      * content tree.
      *
      * @param str
@@ -122,14 +132,14 @@ public interface Jsonb extends AutoCloseable {
      * @return the newly created root object of the java content tree
      *
      * @throws JsonbException
-     *     If any unexpected error(s) occur(s) during deserialization.
+     *      If an unexpected error occurs during deserialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      */
     <T> T fromJson(String str, Class<T> type) throws JsonbException;
 
     /**
-     * Reads in a JSON data from the specified string and return the resulting
+     * Reads JSON data from the specified string and returns the resulting
      * content tree.
      *
      * @param str
@@ -142,18 +152,18 @@ public interface Jsonb extends AutoCloseable {
      * @return the newly created root object of the java content tree
      *
      * @throws JsonbException
-     *     If any unexpected error(s) occur(s) during deserialization.
+     *      If an unexpected error occurs during deserialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      */
     <T> T fromJson(String str, Type runtimeType) throws JsonbException;
 
     /**
-     * Reads in a JSON data from the specified Reader and return the
+     * Reads JSON data from the specified {@code reader} and returns the
      * resulting content tree.
      *
      * @param reader
-     *      The character stream is read as a JSON data.
+     *      The character stream from which to read JSON data.
      * @param type
      *      Type of the content tree's root object.
      * @param <T>
@@ -162,18 +172,18 @@ public interface Jsonb extends AutoCloseable {
      * @return the newly created root object of the java content tree
      *
      * @throws JsonbException
-     *     If any unexpected error(s) occur(s) during deserialization.
+     *      If an unexpected error occurs during deserialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      */
     <T> T fromJson(Reader reader, Class<T> type) throws JsonbException;
 
     /**
-     * Reads in a JSON data from the specified Reader and return the
+     * Reads JSON data from the specified {@code reader} and returns the
      * resulting content tree.
      *
      * @param reader
-     *      The character stream is read as a JSON data.
+     *      The character stream from which to read JSON data.
      *
      * @param runtimeType
      *      Runtime type of the content tree's root object.
@@ -181,43 +191,43 @@ public interface Jsonb extends AutoCloseable {
      * @param <T>
      *      Type of the content tree's root object.
      *
-     * @return the newly created root object of the java content tree
+     * @return the newly created root object of the Java content tree
      *
      * @throws JsonbException
-     *     If any unexpected error(s) occur(s) during deserialization.
+     *      If an unexpected error occurs during deserialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      */
     <T> T fromJson(Reader reader, Type runtimeType) throws JsonbException;
 
     /**
-     * Reads in a JSON data from the specified InputStream and return the
+     * Reads JSON data from the specified {@code InputStream} and returns the
      * resulting content tree.
      *
      * @param stream
-     *      The stream is read as a JSON data. Upon a
-     *      successful completion, the stream will be closed by this method.
+     *      The stream from which to read JSON data. Upon
+     *      successful completion, the stream is closed by this method.
      * @param type
      *      Type of the content tree's root object.
      * @param <T>
      *      Type of the content tree's root object.
      *
-     * @return the newly created root object of the java content tree
+     * @return the newly created root object of the Java content tree
      *
      * @throws JsonbException
-     *     If any unexpected error(s) occur(s) during deserialization.
+     *      If an unexpected error occurs during deserialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      */
     <T> T fromJson(InputStream stream, Class<T> type) throws JsonbException;
 
     /**
-     * Reads in a JSON data from the specified InputStream and return the
+     * Reads JSON data from the specified {@code InputStream} and returns the
      * resulting content tree.
      *
      * @param stream
-     *      The stream is read as a JSON data. Upon a
-     *      successful completion, the stream will be closed by this method.
+     *      The stream from which to read JSON data. Upon
+     *      successful completion, the stream is closed by this method.
      *
      * @param runtimeType
      *      Runtime type of the content tree's root object.
@@ -225,26 +235,27 @@ public interface Jsonb extends AutoCloseable {
      * @param <T>
      *      Type of the content tree's root object.
      *
-     * @return the newly created root object of the java content tree
+     * @return the newly created root object of the Java content tree
      *
      * @throws JsonbException
-     *     If any unexpected error(s) occur(s) during deserialization.
+     *      If an unexpected error occurs during deserialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      */
     <T> T fromJson(InputStream stream, Type runtimeType) throws JsonbException;
 
     /**
-     * Writes the Java object tree with root object {@code object} to a String
-     * instance as JSON.
+     * Writes the Java object tree with the given root object, {@code object},
+     * to a {@code String} instance as JSON.
      *
      * @param object
-     *      The root object of the object content tree to be serialized. Must not be null.
+     *      The root object of the object content tree to be serialized.
+     *      Must not be {@code null}.
      *
      * @return String instance with serialized JSON data.
      *
      * @throws JsonbException If any unexpected problem occurs during the
-     * serialization, such as I/O error.
+     *      serialization, such as an I/O error.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      *
@@ -253,20 +264,22 @@ public interface Jsonb extends AutoCloseable {
     String toJson(Object object) throws JsonbException;
 
     /**
-     * Writes the Java object tree with root object {@code object} to a String
-     * instance as JSON.
+     * Writes the Java object tree with the given root object, {@code object},
+     * to a {@code String} instance as JSON.
      *
      * @param object
-     *      The root object of the object content tree to be serialized. Must not be null.
+     *      The root object of the object content tree to be serialized.
+     *      Must not be {@code null}.
      *
      * @param runtimeType
-     *      Runtime type of the content tree's root object. Provided type needs to be
-     *      related to the type of the instance.
+     *      Runtime type of the content tree's root object. The provided
+     *      {@code runtimeType} must be a supertype of, or the same type as,
+     *      the actual class of the provided {@code object}.
      *
      * @return String instance with serialized JSON data.
      *
      * @throws JsonbException If any unexpected problem occurs during the
-     * serialization, such as I/O error.
+     *      serialization, such as an I/O error.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      *
@@ -275,7 +288,7 @@ public interface Jsonb extends AutoCloseable {
     String toJson(Object object, Type runtimeType) throws JsonbException;
 
     /**
-     * Writes the object content tree into a Writer character stream.
+     * Writes the object content tree into a {@code Writer} character stream.
      *
      * @param object
      *      The object content tree to be serialized.
@@ -284,7 +297,7 @@ public interface Jsonb extends AutoCloseable {
      *      {@link Writer}.
      *
      * @throws JsonbException If any unexpected problem occurs during the
-     * serialization.
+     *      serialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      *
@@ -293,21 +306,22 @@ public interface Jsonb extends AutoCloseable {
     void toJson(Object object, Writer writer) throws JsonbException;
 
     /**
-     * Writes the object content tree into a Writer character stream.
+     * Writes the object content tree into a {@code Writer} character stream.
      *
      * @param object
      *      The object content tree to be serialized.
      *
      * @param runtimeType
-     *      Runtime type of the content tree's root object. Provided type needs to be
-     *      related to the type of the instance.
+     *      Runtime type of the content tree's root object. The provided
+     *      {@code runtimeType} must be a supertype of, or the same type as,
+     *      the actual class of the provided {@code object}.
      *
      * @param writer
      *      The JSON will be sent as a character stream to the given
      *      {@link Writer}.
      *
      * @throws JsonbException If any unexpected problem occurs during the
-     * serialization.
+     *      serialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      *
@@ -316,17 +330,17 @@ public interface Jsonb extends AutoCloseable {
     void toJson(Object object, Type runtimeType, Writer writer) throws JsonbException;
 
     /**
-     * Writes the object content tree into output stream.
+     * Writes the object content tree to the given {@code stream}.
      *
      * @param object
      *      The object content tree to be serialized.
      * @param stream
      *      The JSON will be sent as a byte stream to the given
-     *      {@link OutputStream}. Upon a successful completion, the stream will be closed
-     *      by this method.
+     *      {@link OutputStream}. Upon successful completion, the stream is
+     *      closed by this method.
      *
      * @throws JsonbException If any unexpected problem occurs during the
-     * serialization.
+     *      serialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      *
@@ -335,22 +349,23 @@ public interface Jsonb extends AutoCloseable {
     void toJson(Object object, OutputStream stream) throws JsonbException;
 
     /**
-     * Writes the object content tree into output stream.
+     * Writes the object content tree to the given {@code stream}.
      *
      * @param object
      *      The object content tree to be serialized.
      *
      * @param runtimeType
-     *      Runtime type of the content tree's root object. Provided type needs to be
-     *      related to the type of the instance.
+     *      Runtime type of the content tree's root object. The provided
+     *      {@code runtimeType} must be a supertype of, or the same type as,
+     *      the actual class of the provided {@code object}.
      *
      * @param stream
      *      The JSON will be sent as a byte stream to the given
-     *      {@link OutputStream}. Upon a successful completion, the stream will be closed
-     *      by this method.
+     *      {@link OutputStream}. Upon successful completion, the stream is
+     *      closed by this method.
      *
      * @throws JsonbException If any unexpected problem occurs during the
-     * serialization.
+     *      serialization.
      * @throws NullPointerException
      *      If any of the parameters is {@code null}.
      *

--- a/api/src/main/java/jakarta/json/bind/Jsonb.java
+++ b/api/src/main/java/jakarta/json/bind/Jsonb.java
@@ -98,7 +98,7 @@ import java.lang.reflect.Type;
  * <a href="http://tools.ietf.org/html/rfc7159">RFC 7159</a> and which is
  * also supported by Java Platform.
  *
- * <p>For optimal performance, reuse {@code JsonbBuilder} and {@code Jsonb}
+ * <p>For optimal performance, reuse {@code Jsonb}
  * instances. For a typical use-case, only one {@code Jsonb} instance is
  * required by an application.
  *

--- a/api/src/main/java/jakarta/json/bind/package-info.java
+++ b/api/src/main/java/jakarta/json/bind/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,12 +15,43 @@
  */
 
 /**
- * Provides JSON Binding API, which enables binding Java objects from and to
- * JSON documents.
+ * Provides the JSON Binding API, which enables binding Java objects to and
+ * from JSON documents.
  *
- * Main user entry points to the API is {@link jakarta.json.bind.JsonbBuilder JsonbBuilder}
- * which builds {@link jakarta.json.bind.Jsonb Jsonb} instances.
+ * <p>The main entry point to the API is {@link JsonbBuilder}, which builds
+ * a {@link jakarta.json.bind.Jsonb Jsonb} instance that you use to read and
+ * write JSON documents. For example,
  *
+ * <pre>{@code
+ *   public record Lake(String name, int area, int maxDepth) {
+ *   }
+ *
+ *   String json = """
+ *             [
+ *              { "name": "Lake Superior", "area": 31700, "maxDepth": 1333 },
+ *              { "name": "Lake Michigan", "area": 22300, "maxDepth": 925  },
+ *              { "name": "Lake Huron",    "area": 23000, "maxDepth": 750  }
+ *             ]
+ *             """;
+ *
+ *   Jsonb jsonb = JsonbBuilder.create();
+ *
+ *   Lake[] lakes = jsonb.fromJson(json, Lake[].class);
+ *
+ *   String name = lakes[0].name();     // "Lake Superior"
+ *   int   depth = lakes[0].maxDepth(); // 1333
+ *
+ *   String json_superior = jsonb.toJson(lakes[0]);
+ *
+ *   // Close if no longer needed; a Jsonb instance should be reused throughout the application
+ *   jsonb.close();
+ * }</pre>
+ *
+ * <p>The {@linkplain jakarta.json.bind/ module Javadoc} has additional examples.
+ *
+ * @see jakarta.json.bind.Jsonb
+ * @see jakarta.json.bind.JsonbBuilder
+ * @see jakarta.json.bind.JsonbConfig
  * @since JSON Binding 1.0
  */
 package jakarta.json.bind;

--- a/api/src/main/java/jakarta/json/bind/package-info.java
+++ b/api/src/main/java/jakarta/json/bind/package-info.java
@@ -43,7 +43,7 @@
  *
  *   String json_superior = jsonb.toJson(lakes[0]);
  *
- *   // Close if no longer needed; a Jsonb instance should be reused throughout the application
+ *   // Close if no longer needed; a Jsonb instance should be reused throughout the application.
  *   jsonb.close();
  * }</pre>
  *

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,7 +15,109 @@
  */
 
 /**
- * Jakarta JSON Binding API.
+ * Jakarta JSON Binding (JSON-B) defines a standard binding layer for
+ * converting Java objects to and from JSON documents. It provides a
+ * default mapping that covers the most common Java types and a rich
+ * set of annotations and configuration options for customising that
+ * mapping.
+ *
+ * <p>{@link jakarta.json.bind.JsonbBuilder} is the starting point to
+ * create a {@link jakarta.json.bind.Jsonb} instance, which is then used
+ * to serialise and deserialise Java objects.
+ *
+ * <h2>JSON property names</h2>
+ *
+ * <h3>Names from fields and record components</h3>
+ *
+ * <p>The examples below demonstrate how JSON-B maps a string, a boolean,
+ * a number, an array, a nested object, and an enum:
+ *
+ * <pre>{@code
+ *   public class Planet {
+ *       public String       name;
+ *       public boolean      isHabitable;
+ *       public long         mass;
+ *       public List<String> moons;
+ *       public Star         star;
+ *   }
+ *
+ *   public record Star(String name, StarType type) {}
+ *
+ *   public enum StarType { MAIN_SEQUENCE, GIANT, DWARF }
+ * }</pre>
+ *
+ * <p>Conversion of a Java object to JSON and then back to a Java object:
+ *
+ * <pre>{@code
+ *   Jsonb jsonb = JsonbBuilder.create();
+ *
+ *   Planet mars = new Planet();
+ *   mars.name = "Mars";
+ *   mars.isHabitable = false;
+ *   mars.mass = 641693L;
+ *   mars.moons = List.of("Phobos", "Deimos");
+ *   mars.star = new Star("Sol", StarType.MAIN_SEQUENCE);
+ *
+ *   String json = jsonb.toJson(mars);
+ *
+ *   // Generated JSON:
+ *   // {
+ *   //  "name": "Mars",
+ *   //  "isHabitable": false,
+ *   //  "mass": 641693,
+ *   //  "moons": ["Phobos", "Deimos"],
+ *   //  "star": {
+ *   //           "name": "Sol",
+ *   //           "type": "MAIN_SEQUENCE"
+ *   //          }
+ *   // }
+ *
+ *   Planet planet = jsonb.fromJson(json, Planet.class);
+ *
+ *   // Close if no longer needed; a Jsonb instance should be reused throughout the application
+ *   jsonb.close();
+ * }</pre>
+ *
+ * <h3>Names from accessor methods</h3>
+ *
+ * <p>JSON property can be derived from names of accessor methods with
+ * {@code public} visibility. In the following class the {@code period} field
+ * is package-private, so it does not determine the name of a JSON-B property.
+ * The field is exposed through accessor methods named {@code getOrbitalPeriod}
+ * and {@code setOrbitalPeriod}, so the JSON property name is
+ * {@code "orbitalPeriod"}:
+ *
+ * <pre>{@code
+ *   public class Comet {
+ *       String name;
+ *       int period;
+ *
+ *       public String getName()                   { return name; }
+ *       public int    getOrbitalPeriod()          { return period; }
+ *
+ *       public void   setName(String value)       { name = value; }
+ *       public void   setOrbitalPeriod(int value) { period = value; }
+ *   }
+ * }</pre>
+ *
+ * <pre>{@code    String json = """
+ *           {
+ *             "name": "Halley",
+ *             "orbitalPeriod": 75
+ *           }
+ *           """;
+ *
+ *   Comet comet = jsonb.fromJson(json, Comet.class);
+ *   String name   = comet.getName();          // "Halley"
+ *   int    period = comet.getOrbitalPeriod(); // 75
+ * }</pre>
+ *
+ * <p>For advanced configuration (custom serializers, date formats, property
+ * naming strategies, etc.) see {@link jakarta.json.bind.JsonbConfig}.
+ *
+ * @see jakarta.json.bind.Jsonb
+ * @see jakarta.json.bind.JsonbBuilder
+ * @see jakarta.json.bind.JsonbConfig
  */
 module jakarta.json.bind {
     exports jakarta.json.bind;

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -18,7 +18,7 @@
  * Jakarta JSON Binding (JSON-B) defines a standard binding layer for
  * converting Java objects to and from JSON documents. It provides a
  * default mapping that covers the most common Java types and a rich
- * set of annotations and configuration options for customising that
+ * set of annotations and configuration options for customizing that
  * mapping.
  *
  * <p>{@link jakarta.json.bind.JsonbBuilder} is the starting point to
@@ -80,7 +80,7 @@
  *
  * <h3>Names from accessor methods</h3>
  *
- * <p>JSON property can be derived from names of accessor methods with
+ * <p>A JSON property can be derived from names of accessor methods with
  * {@code public} visibility. In the following class the {@code period} field
  * is package-private, so it does not determine the name of a JSON-B property.
  * The field is exposed through accessor methods named {@code getOrbitalPeriod}

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -80,7 +80,7 @@
  *
  * <h3>Names from accessor methods</h3>
  *
- * <p>A JSON property can be derived from names of accessor methods with
+ * <p>A JSON property name can be derived from the name of an accessor method with
  * {@code public} visibility. In the following class the {@code period} field
  * is package-private, so it does not determine the name of a JSON property.
  * The field is exposed through accessor methods named {@code getOrbitalPeriod}

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -82,7 +82,7 @@
  *
  * <p>A JSON property can be derived from names of accessor methods with
  * {@code public} visibility. In the following class the {@code period} field
- * is package-private, so it does not determine the name of a JSON-B property.
+ * is package-private, so it does not determine the name of a JSON property.
  * The field is exposed through accessor methods named {@code getOrbitalPeriod}
  * and {@code setOrbitalPeriod}, so the JSON property name is
  * {@code "orbitalPeriod"}:

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -74,7 +74,7 @@
  *
  *   Planet planet = jsonb.fromJson(json, Planet.class);
  *
- *   // Close if no longer needed; a Jsonb instance should be reused throughout the application
+ *   // Close if no longer needed; a Jsonb instance should be reused throughout the application.
  *   jsonb.close();
  * }</pre>
  *


### PR DESCRIPTION
The official page for the Jakarta JSON Binding specification,
https://jakarta.ee/specifications/jsonb/3.1/

includes a link to the Javadoc for the spec, starting with this page
[Jakarta JSON Binding 3.1 Javadoc](https://jakarta.ee/specifications/jsonb/3.1/M1/apidocs)

which unfortunately consists only of the words: `Jakarta JSON Binding API.`

This landing page is an excellent place for us to put a few basic copy/pasteable examples from which new users can get started out, and which illustrates at a high level what the specification generally offers.

In this PR, I tried to add something along those lines, as well as for the also currently sparse page for the jakarta.json.bind package. Additionally, I reviewed the Jsonb class and proposed some updates which are hopefully improvements there.